### PR TITLE
feat: [FFM-3688]: Ensure both pollInterval and eventSyncInterval adhere to a lower cap of 60s

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,22 +1,85 @@
 import Client from '../client';
 import { PollingProcessor } from '../polling';
+import { defaultOptions } from '../constants';
 
 jest.mock('../openapi/api');
 
-it('should close the client when the close method is called', async () => {
-  // given
-  const start = jest.spyOn(PollingProcessor.prototype, 'start');
-  const close = jest.spyOn(PollingProcessor.prototype, 'close');
+describe('Client', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
 
-  // when
-  const client = new Client('some key', {
-    enableAnalytics: false,
+  it('should close the client when the close method is called', async () => {
+    // given
+    const start = jest.spyOn(PollingProcessor.prototype, 'start');
+    const close = jest.spyOn(PollingProcessor.prototype, 'close');
+
+    // when
+    const client = new Client('some key', {
+      enableAnalytics: false,
+    });
+    await client.waitForInitialization();
+
+    client.close();
+
+    // then
+    expect(start).toBeCalledTimes(1);
+    expect(close).toBeCalledTimes(1);
   });
-  await client.waitForInitialization();
 
-  client.close();
+  it('should warn if poll interval is set below the default', async () => {
+    jest.spyOn(PollingProcessor.prototype, 'start').mockReturnValue(undefined)
+    const warnSpy = jest.spyOn(console, 'warn').mockReturnValue(undefined);
 
-  // then
-  expect(start).toBeCalledTimes(1);
-  expect(close).toBeCalledTimes(1);
+    new Client('some key', {
+      pollInterval: defaultOptions.pollInterval,
+      enableAnalytics: false,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockReset();
+
+    new Client('some key', {
+      pollInterval: defaultOptions.pollInterval - 1,
+      enableAnalytics: false,
+    });
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockReset();
+
+    new Client('some key', {
+      pollInterval: defaultOptions.pollInterval + 1,
+      enableAnalytics: false,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should warn if events sync interval is set below the default', async () => {
+    jest.spyOn(PollingProcessor.prototype, 'start').mockReturnValue(undefined)
+    const warnSpy = jest.spyOn(console, 'warn');
+
+    new Client('some key', {
+      eventsSyncInterval: defaultOptions.eventsSyncInterval,
+      enableAnalytics: false,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockReset();
+
+    new Client('some key', {
+      eventsSyncInterval: defaultOptions.eventsSyncInterval - 1,
+      enableAnalytics: false,
+    });
+
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockReset();
+
+    new Client('some key', {
+      eventsSyncInterval: defaultOptions.eventsSyncInterval + 1,
+      enableAnalytics: false,
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -59,9 +59,14 @@ export default class Client {
     this.options = { ...defaultOptions, ...options };
     this.log = this.options.logger;
 
-    if (options.pollInterval < 1000) {
+    if (options.pollInterval < defaultOptions.pollInterval) {
       this.options.pollInterval = defaultOptions.pollInterval;
-      this.log.warn('Polling interval cannot be lower than 1000 ms');
+      this.log.warn(`Polling interval cannot be lower than ${defaultOptions.pollInterval} ms`);
+    }
+
+    if (options.eventsSyncInterval < defaultOptions.eventsSyncInterval) {
+      this.options.eventsSyncInterval = defaultOptions.eventsSyncInterval;
+      this.log.warn(`Events sync interval cannot be lower than ${defaultOptions.eventsSyncInterval} ms`);
     }
 
     this.configuration = new Configuration({


### PR DESCRIPTION
This PR ensures that the `pollInterval` and `eventSyncInterval` cannot be set lower than 60s.

Refs [FFM-3688](https://harness.atlassian.net/browse/FFM-3688)
