### PR TITLE
fix: [FFM-4494]: Only fetch when create/edit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.2.6",
+  "version": "1.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Feature flags SDK for NodeJS environments",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -103,9 +103,12 @@ export class StreamProcessor {
   ): Promise<void> {
     this.log.info('Processing message', msg);
     try {
-      const response = await fn(msg.identifier, this.environment, this.cluster);
-      const data: FeatureConfig | Segment = response.data;
       if (msg.event === 'create' || msg.event === 'patch') {
+        const { data } = await fn(
+          msg.identifier,
+          this.environment,
+          this.cluster,
+        );
         setFn(msg.identifier, data);
       } else if (msg.event === 'delete') {
         delFn(msg.identifier);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "1.2.7";
+export const VERSION = "1.2.8";


### PR DESCRIPTION
This PR moves the call to fetch a Target Group/Flag into the create/patch condition to prevent it being called for delete events.