### PR TITLE
[FFM-5387]: Update Test Cases

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -113,7 +113,7 @@ export class Evaluator {
       if (segment) {
         // Should Target be excluded - if in excluded list we return false
         if (
-          segment.excluded.find(
+          segment.excluded?.find(
             (value: ApiTarget) => value.identifier === target.identifier,
           )
         ) {
@@ -127,7 +127,7 @@ export class Evaluator {
 
         // Should Target be included - if in included list we return true
         if (
-          segment.included.find(
+          segment.included?.find(
             (value: ApiTarget) => value.identifier === target.identifier,
           )
         ) {


### PR DESCRIPTION
Update the test-cases submodule.
This pulls in over 70 new tests for the evaluator.

The evaluator test had to be updated to understand the newer format.  We also had to modify how the JSON results are confirmed.