### PR TITLE
FFM-7198 Bump ff-eventsource to 2.1.3 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@harnessio/eventsource": "^2.1.2",
+        "@harnessio/eventsource": "^2.1.3",
         "axios": "^0.22.0",
         "axios-retry": "^3.2.0",
         "jwt-decode": "^3.1.2",
@@ -670,8 +670,9 @@
       }
     },
     "node_modules/@harnessio/eventsource": {
-      "version": "2.1.2",
-      "license": "MIT",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@harnessio/eventsource/-/eventsource-2.1.3.tgz",
+      "integrity": "sha512-S3L45yxeWzoUOhCihXsRoqgip4uRrtQU/6GFe5OVgcZtuqjWDMRmABc3iEDTOTJFZL7B9G4pavP5HriBI2vMGg==",
       "dependencies": {
         "retry": "^0.13.1"
       },
@@ -7168,7 +7169,9 @@
       }
     },
     "@harnessio/eventsource": {
-      "version": "2.1.2",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@harnessio/eventsource/-/eventsource-2.1.3.tgz",
+      "integrity": "sha512-S3L45yxeWzoUOhCihXsRoqgip4uRrtQU/6GFe5OVgcZtuqjWDMRmABc3iEDTOTJFZL7B9G4pavP5HriBI2vMGg==",
       "requires": {
         "retry": "^0.13.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "description": "Feature flags SDK for NodeJS environments",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "axios": "^0.22.0",
     "axios-retry": "^3.2.0",
-    "@harnessio/eventsource": "^2.1.2",
+    "@harnessio/eventsource": "^2.1.3",
     "jwt-decode": "^3.1.2",
     "keyv": "^4.0.3",
     "keyv-file": "^0.2.0",


### PR DESCRIPTION
# What
Bumps ff-eventsource to 2.1.3 and release prep for Node SDK 1.2.14