### PR TITLE
FFM-7412 - Bump ff-eventsource dependency to fix socket leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "description": "Feature flags SDK for NodeJS environments",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",
@@ -63,7 +63,7 @@
   "dependencies": {
     "axios": "^0.22.0",
     "axios-retry": "^3.2.0",
-    "@harnessio/eventsource": "^2.1.4",
+    "@harnessio/eventsource": "^2.1.5",
     "jwt-decode": "^3.1.2",
     "keyv": "^4.0.3",
     "keyv-file": "^0.2.0",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "1.2.15";
+export const VERSION = "1.2.16";


### PR DESCRIPTION
FFM-7412 - Bump ff-eventsource dependency to fix socket leak

What
This updates the Harness fork of the eventsource lib to use an updated bug fixed version: If we're already retrying a stream endpoint, avoid scheduling another retry. Instead let the existing retry run its course.

Why
We're seeing the SDK endlessly spin with retries when a stream endpoint drops.

Testing
Tested manually with a custom proxy to drop the stream endpoint and reproduce the spin