### PR TITLE
FFM-8116 Stop SSE when `Client.close()` is called

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-nodejs-server-sdk",
-      "version": "1.2.16",
+      "version": "1.2.17",
       "bundleDependencies": [
         "axios",
         "eventsource",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "description": "Feature flags SDK for NodeJS environments",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -1,13 +1,12 @@
 import EventEmitter from 'events';
-import {AxiosPromise} from 'axios';
-import {ClientApi, FeatureConfig, Segment} from './openapi';
-import {StreamEvent, Options, StreamMsg} from './types';
-import {Repository} from './repository';
-import {ConsoleLog} from './log';
+import { AxiosPromise } from 'axios';
+import { ClientApi, FeatureConfig, Segment } from './openapi';
+import { StreamEvent, Options, StreamMsg } from './types';
+import { Repository } from './repository';
+import { ConsoleLog } from './log';
 
-import https, {RequestOptions} from 'https';
+import https, { RequestOptions } from 'https';
 import http from 'http';
-
 
 type FetchFunction = (
   identifier: string,
@@ -68,7 +67,6 @@ export class StreamProcessor {
 
     const url = `${this.options.baseUrl}/stream?cluster=${this.cluster}`;
 
-
     const options = {
       headers: {
         'Cache-Control': 'no-cache',
@@ -126,12 +124,12 @@ export class StreamProcessor {
       this.abortController.abort();
     }
     this.abortController = new AbortController();
-    const {signal} = this.abortController;
+    const { signal } = this.abortController;
 
     const isSecure = url.startsWith('https:');
     this.log.debug('SSE HTTP start request', url);
 
-    const appendedOptions = {...options, signal};
+    const appendedOptions = { ...options, signal };
 
     (isSecure ? https : http)
       .request(url, appendedOptions, (res) => {
@@ -156,14 +154,12 @@ export class StreamProcessor {
       .on('timeout', () => {
         onFailed(
           'SSE request timed out after ' +
-          StreamProcessor.SSE_TIMEOUT_MS +
-          'ms',
+            StreamProcessor.SSE_TIMEOUT_MS +
+            'ms',
         );
       })
       .setTimeout(StreamProcessor.SSE_TIMEOUT_MS)
       .end();
-
-
   }
 
   private processData(data: any): void {
@@ -203,7 +199,7 @@ export class StreamProcessor {
     this.log.info('Processing message', msg);
     try {
       if (msg.event === 'create' || msg.event === 'patch') {
-        const {data} = await fn(
+        const { data } = await fn(
           msg.identifier,
           this.environment,
           this.cluster,
@@ -228,18 +224,18 @@ export class StreamProcessor {
     return this.readyState === StreamProcessor.CONNECTED;
   }
 
-
   close(): void {
-    if (this.readyState == StreamProcessor.CONNECTED || this.readyState == StreamProcessor.RETRYING) {
+    if (
+      this.readyState == StreamProcessor.CONNECTED ||
+      this.readyState == StreamProcessor.RETRYING
+    ) {
       this.readyState = StreamProcessor.CLOSED;
       this.log.info('Closing StreamProcessor');
-      this.abortController.abort()
+      this.abortController.abort();
       this.eventBus.emit(StreamEvent.DISCONNECTED);
       this.log.info('StreamProcessor closed');
     } else {
       this.log.info('SteamProcessor already closed');
     }
-
-
   }
 }

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -31,7 +31,7 @@ export class StreamProcessor {
   private options: Options;
   // Abort requests from users running Node.js version 15 and above
   private abortController: AbortController;
-  // Abort requests from users running Node.js version 12 to 14
+  // Store the request so we can abort it later from users running Node.js version 12 to 14
   private request: ClientRequest;
   private eventBus: EventEmitter;
   private readyState: number;

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -165,8 +165,8 @@ export class StreamProcessor {
             'ms',
         );
       })
-      .setTimeout(StreamProcessor.SSE_TIMEOUT_MS)
-      this.request.end()
+      .setTimeout(StreamProcessor.SSE_TIMEOUT_MS);
+    this.request.end();
   }
 
   private processData(data: any): void {

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -1,11 +1,11 @@
 import EventEmitter from 'events';
-import { AxiosPromise } from 'axios';
-import { ClientApi, FeatureConfig, Segment } from './openapi';
-import { StreamEvent, Options, StreamMsg } from './types';
-import { Repository } from './repository';
-import { ConsoleLog } from './log';
+import {AxiosPromise} from 'axios';
+import {ClientApi, FeatureConfig, Segment} from './openapi';
+import {StreamEvent, Options, StreamMsg} from './types';
+import {Repository} from './repository';
+import {ConsoleLog} from './log';
 
-import https, { RequestOptions } from 'https';
+import https, {RequestOptions} from 'https';
 import http from 'http';
 
 
@@ -68,8 +68,6 @@ export class StreamProcessor {
     const url = `${this.options.baseUrl}/stream?cluster=${this.cluster}`;
 
 
-
-
     const options = {
       headers: {
         'Cache-Control': 'no-cache',
@@ -126,12 +124,12 @@ export class StreamProcessor {
       this.abortController.abort();
     }
     const abortController = new AbortController();
-    const { signal } = abortController;
+    const {signal} = abortController;
 
     const isSecure = url.startsWith('https:');
     this.log.debug('SSE HTTP start request', url);
 
-    const newObject = { ...options, signal };
+    const newObject = {...options, signal};
 
     (isSecure ? https : http)
       .request(url, newObject, (res) => {
@@ -156,8 +154,8 @@ export class StreamProcessor {
       .on('timeout', () => {
         onFailed(
           'SSE request timed out after ' +
-            StreamProcessor.SSE_TIMEOUT_MS +
-            'ms',
+          StreamProcessor.SSE_TIMEOUT_MS +
+          'ms',
         );
       })
       .setTimeout(StreamProcessor.SSE_TIMEOUT_MS)
@@ -203,7 +201,7 @@ export class StreamProcessor {
     this.log.info('Processing message', msg);
     try {
       if (msg.event === 'create' || msg.event === 'patch') {
-        const { data } = await fn(
+        const {data} = await fn(
           msg.identifier,
           this.environment,
           this.cluster,
@@ -235,11 +233,9 @@ export class StreamProcessor {
       this.abortController.abort()
       this.eventBus.emit(StreamEvent.DISCONNECTED);
       this.log.info('StreamProcessor closed');
-    }
-    else {
+    } else {
       this.log.info('SteamProcessor already closed');
     }
-
 
 
   }

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -7,6 +7,8 @@ import { ConsoleLog } from './log';
 
 import https, { RequestOptions } from 'https';
 import http from 'http';
+import { AbortController } from 'abort-controller';
+
 
 type FetchFunction = (
   identifier: string,

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -76,7 +76,6 @@ export class StreamProcessor {
         Authorization: `Bearer ${this.jwtToken}`,
         'API-Key': this.apiKey,
       },
-      // signal: { signal }
     };
 
     const onConnected = () => {

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -123,6 +123,7 @@ export class StreamProcessor {
       return;
     }
 
+    // If the user is running Node 15 and greater, we can use AbortController to close the connection
     let appendedOptions = undefined;
     if (typeof AbortController === 'function') {
       // Cleanup the previous AbortController instance if it exists
@@ -137,7 +138,7 @@ export class StreamProcessor {
     const isSecure = url.startsWith('https:');
     this.log.debug('SSE HTTP start request', url);
 
-    (isSecure ? https : http)
+    this.request = (isSecure ? https : http)
       .request(url, appendedOptions ? appendedOptions : options, (res) => {
         this.log.debug('SSE got HTTP response code', res.statusCode);
 
@@ -165,7 +166,7 @@ export class StreamProcessor {
         );
       })
       .setTimeout(StreamProcessor.SSE_TIMEOUT_MS)
-      .end();
+      this.request.end()
   }
 
   private processData(data: any): void {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.2.16';
+export const VERSION = '1.2.17';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "1.2.16";
+export const VERSION = '1.2.16';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.2.16';
+export const VERSION = "1.2.16";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.2.17';
+export const VERSION = "1.2.17";


### PR DESCRIPTION
# What
Adds functionality to abort the SSE stream if `Client.close()` is called. 

# Testing
Manually called `close()` and the SSE connection aborts and does not retry connecting