### PR TITLE
FFM-8289 Stop SDK crashing on auth failures / SDK Codes / JWT Validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.2.17",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-nodejs-server-sdk",
-      "version": "1.2.17",
+      "version": "1.3.0",
       "bundleDependencies": [
         "axios",
         "eventsource",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.2.17",
+  "version": "1.3.0",
   "description": "Feature flags SDK for NodeJS environments",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/src/__tests__/sdk_codes.test.ts
+++ b/src/__tests__/sdk_codes.test.ts
@@ -27,7 +27,6 @@ describe('SDK Tests', () => {
       sdkCodes.debugStreamEventReceived(logger);
       sdkCodes.infoStreamStopped(logger);
       sdkCodes.infoMetricsSuccess(logger);
-      sdkCodes.infoMetricsTargetExceeded(logger);
       sdkCodes.infoMetricsThreadExited(logger);
       sdkCodes.debugEvalSuccess(
         'dummy result',

--- a/src/__tests__/sdk_codes.test.ts
+++ b/src/__tests__/sdk_codes.test.ts
@@ -1,4 +1,4 @@
-import { Logger } from '../log';
+import type { Logger } from '../log';
 import * as sdkCodes from '../sdk_codes';
 
 describe('SDK Tests', () => {

--- a/src/__tests__/sdk_codes.test.ts
+++ b/src/__tests__/sdk_codes.test.ts
@@ -1,0 +1,20 @@
+import { ConsoleLog, Logger } from "../log";
+import * as sdkCodes from '../sdk_codes';
+
+
+describe('SDK Tests', () => {
+  let logger: Logger;
+
+  beforeEach(() => {
+    logger = new ConsoleLog()
+  });
+
+  test('Run all sdk_code functions without raising exceptions', () => {
+    expect(() => {
+      sdkCodes.infoSDKInitOK(logger);
+      sdkCodes.infoSDKCloseSuccess(logger);
+      sdkCodes.infoMetricsThreadStarted(5000, logger);
+      // Call other functions here
+    }).not.toThrow();
+  });
+});

--- a/src/__tests__/sdk_codes.test.ts
+++ b/src/__tests__/sdk_codes.test.ts
@@ -1,11 +1,17 @@
-import { ConsoleLog, Logger } from "../log";
+import { Logger } from "../log";
 import * as sdkCodes from '../sdk_codes';
 
 describe('SDK Tests', () => {
   let logger: Logger;
 
   beforeEach(() => {
-    logger = new ConsoleLog()
+    logger = {
+      trace: jest.fn(),
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
   });
 
   test('Run all sdk_code functions without raising exceptions', () => {

--- a/src/__tests__/sdk_codes.test.ts
+++ b/src/__tests__/sdk_codes.test.ts
@@ -20,7 +20,6 @@ describe('SDK Tests', () => {
       sdkCodes.infoSDKCloseSuccess(logger);
       sdkCodes.infoMetricsThreadStarted(5000, logger);
       sdkCodes.infoPollStarted(60, logger)
-      sdkCodes.infoSDKInitWaiting( logger)
       sdkCodes.infoSDKStartClose( logger)
       sdkCodes.infoSDKAuthOK( logger)
       sdkCodes.infoPollingStopped("Dummy reason", logger)
@@ -30,7 +29,7 @@ describe('SDK Tests', () => {
       sdkCodes.infoMetricsSuccess( logger)
       sdkCodes.infoMetricsTargetExceeded( logger)
       sdkCodes.infoMetricsThreadExited( logger)
-      sdkCodes.debugEvalSuccess( logger)
+      sdkCodes.debugEvalSuccess("dummy result", "dummy identifier", { name: "dummy", identifier: "dummy"}, logger)
       sdkCodes.warnAuthFailedSrvDefaults( logger)
       sdkCodes.warnMissingSDKKey( logger)
       sdkCodes.warnFailedInitAuthError( logger)
@@ -39,7 +38,7 @@ describe('SDK Tests', () => {
       sdkCodes.warnStreamDisconnected("dummy reason", logger)
       sdkCodes.warnStreamRetrying(4, logger)
       sdkCodes.warnPostMetricsFailed("dummy error", logger)
-      sdkCodes.warnDefaultVariationServed("flag", "target", "default value", logger)
+      sdkCodes.warnDefaultVariationServed("flag", { name: "dummy", identifier: "dummy"}, "default value", logger)
       // Call other functions here
     }).not.toThrow();
   });

--- a/src/__tests__/sdk_codes.test.ts
+++ b/src/__tests__/sdk_codes.test.ts
@@ -1,7 +1,7 @@
 import type { Logger } from '../log';
 import * as sdkCodes from '../sdk_codes';
 
-describe('SDK Tests', () => {
+describe('SDK Codes', () => {
   const logger: Logger = {
     trace: jest.fn(),
     debug: jest.fn(),

--- a/src/__tests__/sdk_codes.test.ts
+++ b/src/__tests__/sdk_codes.test.ts
@@ -2,17 +2,13 @@ import { Logger } from '../log';
 import * as sdkCodes from '../sdk_codes';
 
 describe('SDK Tests', () => {
-  let logger: Logger;
-
-  beforeEach(() => {
-    logger = {
-      trace: jest.fn(),
-      debug: jest.fn(),
-      info: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-    };
-  });
+  const logger: Logger = {
+    trace: jest.fn(),
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
 
   test('Run all sdk_code functions without raising exceptions', () => {
     expect(() => {

--- a/src/__tests__/sdk_codes.test.ts
+++ b/src/__tests__/sdk_codes.test.ts
@@ -1,4 +1,4 @@
-import { Logger } from "../log";
+import { Logger } from '../log';
 import * as sdkCodes from '../sdk_codes';
 
 describe('SDK Tests', () => {
@@ -19,26 +19,36 @@ describe('SDK Tests', () => {
       sdkCodes.infoSDKInitOK(logger);
       sdkCodes.infoSDKCloseSuccess(logger);
       sdkCodes.infoMetricsThreadStarted(5000, logger);
-      sdkCodes.infoPollStarted(60, logger)
-      sdkCodes.infoSDKStartClose( logger)
-      sdkCodes.infoSDKAuthOK( logger)
-      sdkCodes.infoPollingStopped("Dummy reason", logger)
-      sdkCodes.infoStreamConnected( logger)
-      sdkCodes.infoStreamEventReceived( "Dummy event", logger)
-      sdkCodes.infoStreamStopped( logger)
-      sdkCodes.infoMetricsSuccess( logger)
-      sdkCodes.infoMetricsTargetExceeded( logger)
-      sdkCodes.infoMetricsThreadExited( logger)
-      sdkCodes.debugEvalSuccess("dummy result", "dummy identifier", { name: "dummy", identifier: "dummy"}, logger)
-      sdkCodes.warnAuthFailedSrvDefaults( logger)
-      sdkCodes.warnMissingSDKKey( logger)
-      sdkCodes.warnFailedInitAuthError( logger)
-      sdkCodes.warnAuthFailedExceedRetries( logger)
-      sdkCodes.warnAuthRetrying(1, "dummy error", logger)
-      sdkCodes.warnStreamDisconnected("dummy reason", logger)
-      sdkCodes.warnStreamRetrying(4, logger)
-      sdkCodes.warnPostMetricsFailed("dummy error", logger)
-      sdkCodes.warnDefaultVariationServed("flag", { name: "dummy", identifier: "dummy"}, "default value", logger)
+      sdkCodes.infoPollStarted(60, logger);
+      sdkCodes.infoSDKStartClose(logger);
+      sdkCodes.infoSDKAuthOK(logger);
+      sdkCodes.infoPollingStopped(logger);
+      sdkCodes.infoStreamConnected(logger);
+      sdkCodes.debugStreamEventReceived(logger);
+      sdkCodes.infoStreamStopped(logger);
+      sdkCodes.infoMetricsSuccess(logger);
+      sdkCodes.infoMetricsTargetExceeded(logger);
+      sdkCodes.infoMetricsThreadExited(logger);
+      sdkCodes.debugEvalSuccess(
+        'dummy result',
+        'dummy identifier',
+        { name: 'dummy', identifier: 'dummy' },
+        logger,
+      );
+      sdkCodes.warnAuthFailedSrvDefaults(logger);
+      sdkCodes.warnMissingSDKKey(logger);
+      sdkCodes.warnFailedInitAuthError(logger);
+      sdkCodes.warnAuthFailedExceedRetries(logger);
+      sdkCodes.warnAuthRetrying(1, 'dummy error', logger);
+      sdkCodes.warnStreamDisconnected('dummy reason', logger);
+      sdkCodes.warnStreamRetrying(4, logger);
+      sdkCodes.warnPostMetricsFailed('dummy error', logger);
+      sdkCodes.warnDefaultVariationServed(
+        'flag',
+        { name: 'dummy', identifier: 'dummy' },
+        'default value',
+        logger,
+      );
     }).not.toThrow();
   });
 });

--- a/src/__tests__/sdk_codes.test.ts
+++ b/src/__tests__/sdk_codes.test.ts
@@ -30,7 +30,7 @@ describe('SDK Tests', () => {
       sdkCodes.infoMetricsSuccess( logger)
       sdkCodes.infoMetricsTargetExceeded( logger)
       sdkCodes.infoMetricsThreadExited( logger)
-      sdkCodes.infoEvalSuccess( logger)
+      sdkCodes.debugEvalSuccess( logger)
       sdkCodes.warnAuthFailedSrvDefaults( logger)
       sdkCodes.warnMissingSDKKey( logger)
       sdkCodes.warnFailedInitAuthError( logger)

--- a/src/__tests__/sdk_codes.test.ts
+++ b/src/__tests__/sdk_codes.test.ts
@@ -1,7 +1,6 @@
 import { ConsoleLog, Logger } from "../log";
 import * as sdkCodes from '../sdk_codes';
 
-
 describe('SDK Tests', () => {
   let logger: Logger;
 
@@ -14,6 +13,27 @@ describe('SDK Tests', () => {
       sdkCodes.infoSDKInitOK(logger);
       sdkCodes.infoSDKCloseSuccess(logger);
       sdkCodes.infoMetricsThreadStarted(5000, logger);
+      sdkCodes.infoPollStarted(60, logger)
+      sdkCodes.infoSDKInitWaiting( logger)
+      sdkCodes.infoSDKStartClose( logger)
+      sdkCodes.infoSDKAuthOK( logger)
+      sdkCodes.infoPollingStopped("Dummy reason", logger)
+      sdkCodes.infoStreamConnected( logger)
+      sdkCodes.infoStreamEventReceived( "Dummy event", logger)
+      sdkCodes.infoStreamStopped( logger)
+      sdkCodes.infoMetricsSuccess( logger)
+      sdkCodes.infoMetricsTargetExceeded( logger)
+      sdkCodes.infoMetricsThreadExited( logger)
+      sdkCodes.infoEvalSuccess( logger)
+      sdkCodes.warnAuthFailedSrvDefaults( logger)
+      sdkCodes.warnMissingSDKKey( logger)
+      sdkCodes.warnFailedInitAuthError( logger)
+      sdkCodes.warnAuthFailedExceedRetries( logger)
+      sdkCodes.warnAuthRetrying(1, "dummy error", logger)
+      sdkCodes.warnStreamDisconnected("dummy reason", logger)
+      sdkCodes.warnStreamRetrying(4, logger)
+      sdkCodes.warnPostMetricsFailed("dummy error", logger)
+      sdkCodes.warnDefaultVariationServed("flag", "target", "default value", logger)
       // Call other functions here
     }).not.toThrow();
   });

--- a/src/__tests__/sdk_codes.test.ts
+++ b/src/__tests__/sdk_codes.test.ts
@@ -39,7 +39,6 @@ describe('SDK Tests', () => {
       sdkCodes.warnStreamRetrying(4, logger)
       sdkCodes.warnPostMetricsFailed("dummy error", logger)
       sdkCodes.warnDefaultVariationServed("flag", { name: "dummy", identifier: "dummy"}, "default value", logger)
-      // Call other functions here
     }).not.toThrow();
   });
 });

--- a/src/__tests__/sdk_codes.test.ts
+++ b/src/__tests__/sdk_codes.test.ts
@@ -10,40 +10,41 @@ describe('SDK Codes', () => {
     error: jest.fn(),
   };
 
-  test('Run all sdk_code functions without raising exceptions', () => {
-    expect(() => {
-      sdkCodes.infoSDKInitOK(logger);
-      sdkCodes.infoSDKCloseSuccess(logger);
-      sdkCodes.infoMetricsThreadStarted(5000, logger);
-      sdkCodes.infoPollStarted(60, logger);
-      sdkCodes.infoSDKStartClose(logger);
-      sdkCodes.infoSDKAuthOK(logger);
-      sdkCodes.infoPollingStopped(logger);
-      sdkCodes.infoStreamConnected(logger);
-      sdkCodes.debugStreamEventReceived(logger);
-      sdkCodes.infoStreamStopped(logger);
-      sdkCodes.infoMetricsSuccess(logger);
-      sdkCodes.infoMetricsThreadExited(logger);
-      sdkCodes.debugEvalSuccess(
+  test.each([
+    ['infoSDKInitOK', [logger]],
+    ['infoSDKCloseSuccess', [logger]],
+    ['infoMetricsThreadStarted', [5000, logger]],
+    ['infoPollStarted', [60, logger]],
+    ['infoSDKStartClose', [logger]],
+    ['infoSDKAuthOK', [logger]],
+    ['infoPollingStopped', [logger]],
+    ['infoStreamConnected', [logger]],
+    ['debugStreamEventReceived', [logger]],
+    ['infoStreamStopped', [logger]],
+    ['infoMetricsSuccess', [logger]],
+    ['infoMetricsThreadExited', [logger]],
+    [
+      'debugEvalSuccess',
+      [
         'dummy result',
         'dummy identifier',
         { name: 'dummy', identifier: 'dummy' },
         logger,
-      );
-      sdkCodes.warnAuthFailedSrvDefaults(logger);
-      sdkCodes.warnMissingSDKKey(logger);
-      sdkCodes.warnFailedInitAuthError(logger);
-      sdkCodes.warnAuthFailedExceedRetries(logger);
-      sdkCodes.warnAuthRetrying(1, 'dummy error', logger);
-      sdkCodes.warnStreamDisconnected('dummy reason', logger);
-      sdkCodes.warnStreamRetrying(4, logger);
-      sdkCodes.warnPostMetricsFailed('dummy error', logger);
-      sdkCodes.warnDefaultVariationServed(
-        'flag',
-        { name: 'dummy', identifier: 'dummy' },
-        'default value',
-        logger,
-      );
-    }).not.toThrow();
+      ],
+    ],
+    ['warnAuthFailedSrvDefaults', [logger]],
+    ['warnMissingSDKKey', [logger]],
+    ['warnFailedInitAuthError', [logger]],
+    ['warnAuthFailedExceedRetries', [logger]],
+    ['warnAuthRetrying', [1, 'dummy error', logger]],
+    ['warnStreamDisconnected', ['dummy reason', logger]],
+    ['warnStreamRetrying', [4, logger]],
+    ['warnPostMetricsFailed', ['dummy error', logger]],
+    [
+      'warnDefaultVariationServed',
+      ['flag', { name: 'dummy', identifier: 'dummy' }, 'default value', logger],
+    ],
+  ])('it should not throw when %s is called', (fn, args) => {
+    expect(() => sdkCodes[fn](...args)).not.toThrow();
   });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -230,7 +230,7 @@ export default class Client {
       // We unblock the call even if initialization has failed. We've
       // already warned the user that initialization has failed and that
       // defaults will be served
-    } else if (this.failure) {
+    } else if (!this.initialized) {
       this.waitForInitialize = Promise.resolve(this);
     } else {
       this.waitForInitialize = new Promise((resolve, reject) => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -355,6 +355,7 @@ export default class Client {
       );
       return Promise.resolve(defaultValue);
     }
+
     return this.evaluator.boolVariation(
       identifier,
       target,
@@ -381,6 +382,7 @@ export default class Client {
       );
       return Promise.resolve(defaultValue);
     }
+
     return this.evaluator.stringVariation(
       identifier,
       target,
@@ -407,6 +409,7 @@ export default class Client {
       );
       return Promise.resolve(defaultValue);
     }
+
     return this.evaluator.numberVariation(
       identifier,
       target,
@@ -433,6 +436,7 @@ export default class Client {
       );
       return Promise.resolve(defaultValue);
     }
+    
     return this.evaluator.jsonVariation(
       identifier,
       target,

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,14 +17,11 @@ import {
 } from './metrics';
 import { Logger } from './log';
 import {
-  debugEvalSuccess,
-  infoSDKAuthOK,
   infoSDKInitOK,
   warnAuthFailedSrvDefaults,
   warnDefaultVariationServed,
   warnFailedInitAuthError,
 } from './sdk_codes';
-import { Str } from './string';
 
 axios.defaults.timeout = 30000;
 axiosRetry(axios, { retries: 3, retryDelay: axiosRetry.exponentialDelay });

--- a/src/client.ts
+++ b/src/client.ts
@@ -16,7 +16,13 @@ import {
   MetricsProcessorInterface,
 } from './metrics';
 import { Logger } from './log';
-import { infoSDKAuthOK, infoSDKInitOK, warnAuthFailedSrvDefaults, warnFailedInitAuthError } from "./sdk_codes";
+import {
+  infoSDKAuthOK,
+  infoSDKInitOK,
+  warnAuthFailedSrvDefaults,
+  warnDefaultVariationServed,
+  warnFailedInitAuthError
+} from "./sdk_codes";
 
 axios.defaults.timeout = 30000;
 axiosRetry(axios, { retries: 3, retryDelay: axiosRetry.exponentialDelay });
@@ -325,6 +331,10 @@ export default class Client {
     target: Target,
     defaultValue = false,
   ): Promise<boolean> {
+    if (!this.initialized) {
+      warnDefaultVariationServed(identifier, target, defaultValue.toString(), this.log)
+      Promise.resolve(defaultValue)
+    }
     return this.evaluator.boolVariation(
       identifier,
       target,

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,7 +17,10 @@ import {
 } from './metrics';
 import { Logger } from './log';
 import {
-  infoSDKInitOK,
+  infoMetricsThreadStarted,
+  infoPollStarted,
+  infoSDKCloseSuccess,
+  infoSDKInitOK, infoSDKStartClose, infoStreamConnected,
   warnAuthFailedSrvDefaults,
   warnDefaultVariationServed,
   warnFailedInitAuthError, warnMissingSDKKey
@@ -256,14 +259,17 @@ export default class Client {
       case Processor.POLL:
         this.pollerReady = true;
         this.log.debug('PollingProcessor ready');
+        infoPollStarted(this.options.pollInterval, this.log)
         break;
       case Processor.STREAM:
         this.streamReady = true;
         this.log.debug('StreamingProcessor ready');
+        infoStreamConnected(this.log)
         break;
       case Processor.METRICS:
         this.metricReady = true;
         this.log.debug('MetricsProcessor ready');
+        infoMetricsThreadStarted(this.options.eventsSyncInterval, this.log)
         break;
     }
 
@@ -410,6 +416,7 @@ export default class Client {
   }
 
   close(): void {
+    infoSDKStartClose(this.log)
     this.closing = true;
     this.pollProcessor.close();
     if (this.streamProcessor) {
@@ -420,5 +427,6 @@ export default class Client {
     }
     this.eventBus.removeAllListeners();
     this.closing = false;
+    infoSDKCloseSuccess(this.log)
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -199,6 +199,11 @@ export default class Client {
 
       const decoded: Claims = jwt_decode(this.authToken);
 
+      if (!decoded.environment) {
+        this.failure = true;
+        console.error('Error while authenticating, err:  the JWT token has missing claim "environmentUUID" ');
+      }
+
       this.environment = decoded.environment;
       this.cluster = decoded.clusterIdentifier || '1';
     } catch (error) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,11 +17,11 @@ import {
 } from './metrics';
 import { Logger } from './log';
 import {
-  infoSDKInitOK,
+  infoSDKInitOK, infoSDKInitWaiting,
   warnAuthFailedSrvDefaults,
   warnDefaultVariationServed,
-  warnFailedInitAuthError,
-} from './sdk_codes';
+  warnFailedInitAuthError
+} from "./sdk_codes";
 
 axios.defaults.timeout = 30000;
 axiosRetry(axios, { retries: 3, retryDelay: axiosRetry.exponentialDelay });
@@ -221,6 +221,7 @@ export default class Client {
   }
 
   waitForInitialization(): Promise<Client> {
+    infoSDKInitWaiting(this.log)
     if (this.waitForInitialize) {
       return this.waitForInitialize;
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -344,7 +344,7 @@ export default class Client {
       );
       Promise.resolve(defaultValue);
     }
-    const result = this.evaluator.boolVariation(
+    return this.evaluator.boolVariation(
       identifier,
       target,
       defaultValue,
@@ -354,8 +354,6 @@ export default class Client {
         }
       },
     );
-    debugEvalSuccess(`${result}`, identifier, target, this.log);
-    return result;
   }
 
   stringVariation(

--- a/src/client.ts
+++ b/src/client.ts
@@ -372,6 +372,15 @@ export default class Client {
     target: Target,
     defaultValue = '',
   ): Promise<string> {
+    if (!this.initialized) {
+      warnDefaultVariationServed(
+        identifier,
+        target,
+        defaultValue.toString(),
+        this.log,
+      );
+      Promise.resolve(defaultValue);
+    }
     return this.evaluator.stringVariation(
       identifier,
       target,
@@ -389,6 +398,15 @@ export default class Client {
     target: Target,
     defaultValue = 0,
   ): Promise<number> {
+    if (!this.initialized) {
+      warnDefaultVariationServed(
+        identifier,
+        target,
+        defaultValue.toString(),
+        this.log,
+      );
+      Promise.resolve(defaultValue);
+    }
     return this.evaluator.numberVariation(
       identifier,
       target,
@@ -406,6 +424,15 @@ export default class Client {
     target: Target,
     defaultValue = {},
   ): Promise<Record<string, unknown>> {
+    if (!this.initialized) {
+      warnDefaultVariationServed(
+        identifier,
+        target,
+        defaultValue.toString(),
+        this.log,
+      );
+      Promise.resolve(defaultValue);
+    }
     return this.evaluator.jsonVariation(
       identifier,
       target,

--- a/src/client.ts
+++ b/src/client.ts
@@ -20,11 +20,14 @@ import {
   infoMetricsThreadStarted,
   infoPollStarted,
   infoSDKCloseSuccess,
-  infoSDKInitOK, infoSDKStartClose, infoStreamConnected,
+  infoSDKInitOK,
+  infoSDKStartClose,
+  infoStreamConnected,
   warnAuthFailedSrvDefaults,
   warnDefaultVariationServed,
-  warnFailedInitAuthError, warnMissingSDKKey
-} from "./sdk_codes";
+  warnFailedInitAuthError,
+  warnMissingSDKKey,
+} from './sdk_codes';
 
 axios.defaults.timeout = 30000;
 axiosRetry(axios, { retries: 3, retryDelay: axiosRetry.exponentialDelay });
@@ -200,9 +203,9 @@ export default class Client {
 
   private async authenticate(): Promise<void> {
     if (!this.sdkKey) {
-      warnMissingSDKKey(this.log)
-      this.failure = true
-      return
+      warnMissingSDKKey(this.log);
+      this.failure = true;
+      return;
     }
     try {
       const response = await this.api.authenticate({
@@ -259,17 +262,17 @@ export default class Client {
       case Processor.POLL:
         this.pollerReady = true;
         this.log.debug('PollingProcessor ready');
-        infoPollStarted(this.options.pollInterval, this.log)
+        infoPollStarted(this.options.pollInterval, this.log);
         break;
       case Processor.STREAM:
         this.streamReady = true;
         this.log.debug('StreamingProcessor ready');
-        infoStreamConnected(this.log)
+        infoStreamConnected(this.log);
         break;
       case Processor.METRICS:
         this.metricReady = true;
         this.log.debug('MetricsProcessor ready');
-        infoMetricsThreadStarted(this.options.eventsSyncInterval, this.log)
+        infoMetricsThreadStarted(this.options.eventsSyncInterval, this.log);
         break;
     }
 
@@ -416,7 +419,7 @@ export default class Client {
   }
 
   close(): void {
-    infoSDKStartClose(this.log)
+    infoSDKStartClose(this.log);
     this.closing = true;
     this.pollProcessor.close();
     if (this.streamProcessor) {
@@ -427,6 +430,6 @@ export default class Client {
     }
     this.eventBus.removeAllListeners();
     this.closing = false;
-    infoSDKCloseSuccess(this.log)
+    infoSDKCloseSuccess(this.log);
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -353,7 +353,7 @@ export default class Client {
         defaultValue.toString(),
         this.log,
       );
-      Promise.resolve(defaultValue);
+      return Promise.resolve(defaultValue);
     }
     return this.evaluator.boolVariation(
       identifier,
@@ -379,7 +379,7 @@ export default class Client {
         defaultValue.toString(),
         this.log,
       );
-      Promise.resolve(defaultValue);
+      return Promise.resolve(defaultValue);
     }
     return this.evaluator.stringVariation(
       identifier,
@@ -405,7 +405,7 @@ export default class Client {
         defaultValue.toString(),
         this.log,
       );
-      Promise.resolve(defaultValue);
+      return Promise.resolve(defaultValue);
     }
     return this.evaluator.numberVariation(
       identifier,
@@ -431,7 +431,7 @@ export default class Client {
         defaultValue.toString(),
         this.log,
       );
-      Promise.resolve(defaultValue);
+      return Promise.resolve(defaultValue);
     }
     return this.evaluator.jsonVariation(
       identifier,

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -23,7 +23,7 @@ import {
 } from './openapi';
 import murmurhash from 'murmurhash';
 import { ConsoleLog } from './log';
-import { debugEvalSuccess } from "./sdk_codes";
+import { debugEvalSuccess } from './sdk_codes';
 
 type Callback = (
   fc: FeatureConfig,
@@ -397,7 +397,6 @@ export class Evaluator {
       return result;
     }
 
-
     return defaultValue;
   }
 
@@ -455,7 +454,12 @@ export class Evaluator {
       callback,
     );
     if (variation) {
-      debugEvalSuccess(`${JSON.stringify(variation.value)}`, identifier, target, this.log);
+      debugEvalSuccess(
+        `${JSON.stringify(variation.value)}`,
+        identifier,
+        target,
+        this.log,
+      );
       return JSON.parse(variation.value);
     }
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -23,6 +23,7 @@ import {
 } from './openapi';
 import murmurhash from 'murmurhash';
 import { ConsoleLog } from './log';
+import { debugEvalSuccess } from "./sdk_codes";
 
 type Callback = (
   fc: FeatureConfig,
@@ -391,8 +392,11 @@ export class Evaluator {
       callback,
     );
     if (variation) {
-      return variation.value.toLowerCase() === 'true';
+      const result = variation.value.toLowerCase() === 'true';
+      debugEvalSuccess(`${result}`, identifier, target, this.log);
+      return result;
     }
+
 
     return defaultValue;
   }
@@ -410,6 +414,7 @@ export class Evaluator {
       callback,
     );
     if (variation) {
+      debugEvalSuccess(`${variation.value}`, identifier, target, this.log);
       return variation.value;
     }
 
@@ -429,7 +434,9 @@ export class Evaluator {
       callback,
     );
     if (variation) {
-      return parseFloat(variation.value);
+      const result = parseFloat(variation.value);
+      debugEvalSuccess(`${result}`, identifier, target, this.log);
+      return result;
     }
 
     return defaultValue;
@@ -448,7 +455,9 @@ export class Evaluator {
       callback,
     );
     if (variation) {
-      return JSON.parse(variation.value);
+      const result = JSON.parse(variation.value);
+      debugEvalSuccess(`${result}`, identifier, target, this.log);
+      return result;
     }
 
     return defaultValue;

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -455,9 +455,8 @@ export class Evaluator {
       callback,
     );
     if (variation) {
-      const result = JSON.parse(variation.value);
-      debugEvalSuccess(`${result}`, identifier, target, this.log);
-      return result;
+      debugEvalSuccess(`${JSON.stringify(variation.value)}`, identifier, target, this.log);
+      return JSON.parse(variation.value);
     }
 
     return defaultValue;

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -455,7 +455,7 @@ export class Evaluator {
     );
     if (variation) {
       debugEvalSuccess(
-        `${JSON.stringify(variation.value)}`,
+        `${variation.value}`,
         identifier,
         target,
         this.log,

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -23,7 +23,7 @@ import {
 } from './openapi';
 import murmurhash from 'murmurhash';
 import { ConsoleLog } from './log';
-import { debugEvalSuccess } from './sdk_codes';
+import { debugEvalSuccess, warnDefaultVariationServed } from './sdk_codes';
 
 type Callback = (
   fc: FeatureConfig,
@@ -396,7 +396,12 @@ export class Evaluator {
       debugEvalSuccess(`${result}`, identifier, target, this.log);
       return result;
     }
-
+    warnDefaultVariationServed(
+      identifier,
+      target,
+      defaultValue.toString(),
+      this.log,
+    );
     return defaultValue;
   }
 
@@ -416,7 +421,12 @@ export class Evaluator {
       debugEvalSuccess(`${variation.value}`, identifier, target, this.log);
       return variation.value;
     }
-
+    warnDefaultVariationServed(
+      identifier,
+      target,
+      defaultValue.toString(),
+      this.log,
+    );
     return defaultValue;
   }
 
@@ -437,7 +447,12 @@ export class Evaluator {
       debugEvalSuccess(`${result}`, identifier, target, this.log);
       return result;
     }
-
+    warnDefaultVariationServed(
+      identifier,
+      target,
+      defaultValue.toString(),
+      this.log,
+    );
     return defaultValue;
   }
 
@@ -454,15 +469,15 @@ export class Evaluator {
       callback,
     );
     if (variation) {
-      debugEvalSuccess(
-        `${variation.value}`,
-        identifier,
-        target,
-        this.log,
-      );
+      debugEvalSuccess(`${variation.value}`, identifier, target, this.log);
       return JSON.parse(variation.value);
     }
-
+    warnDefaultVariationServed(
+      identifier,
+      target,
+      defaultValue.toString(),
+      this.log,
+    );
     return defaultValue;
   }
 }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -24,7 +24,11 @@ import {
 } from './openapi';
 import { Options, Target } from './types';
 import { VERSION } from './version';
-import { infoMetricsSuccess, infoMetricsThreadExited, warnPostMetricsFailed } from "./sdk_codes";
+import {
+  infoMetricsSuccess,
+  infoMetricsThreadExited,
+  warnPostMetricsFailed,
+} from './sdk_codes';
 
 export enum MetricEvent {
   READY = 'metrics_ready',
@@ -54,7 +58,7 @@ export const MetricsProcessor = (
   conf: Configuration,
   options: Options,
   eventBus: events.EventEmitter,
-  closed = false
+  closed = false,
 ): MetricsProcessorInterface => {
   const data: Map<string, AnalyticsEvent> = new Map<string, AnalyticsEvent>();
   let syncInterval: NodeJS.Timeout;
@@ -180,7 +184,7 @@ export const MetricsProcessor = (
 
   const _send = (): void => {
     if (closed) {
-      return
+      return;
     }
 
     const metrics: Metrics = _summarize();
@@ -190,7 +194,7 @@ export const MetricsProcessor = (
         .postMetrics(environment, cluster, metrics)
         .then((response) => {
           log.debug('Metrics server returns: ', response.status);
-          infoMetricsSuccess(log)
+          infoMetricsSuccess(log);
           if (response.status >= 400) {
             log.error(
               'Error while sending metrics data with status code: ',
@@ -199,7 +203,7 @@ export const MetricsProcessor = (
           }
         })
         .catch((error: Error) => {
-          warnPostMetricsFailed(`${error}`, log)
+          warnPostMetricsFailed(`${error}`, log);
           log.debug('Metrics server returns error: ', error);
         });
     }
@@ -218,9 +222,9 @@ export const MetricsProcessor = (
     log.info('Closing MetricsProcessor');
     clearInterval(syncInterval);
     _send();
-    closed = true
+    closed = true;
     log.info('MetricsProcessor closed');
-    infoMetricsThreadExited(log)
+    infoMetricsThreadExited(log);
   };
 
   return {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -54,6 +54,7 @@ export const MetricsProcessor = (
   conf: Configuration,
   options: Options,
   eventBus: events.EventEmitter,
+  closed = false
 ): MetricsProcessorInterface => {
   const data: Map<string, AnalyticsEvent> = new Map<string, AnalyticsEvent>();
   let syncInterval: NodeJS.Timeout;
@@ -178,6 +179,10 @@ export const MetricsProcessor = (
   };
 
   const _send = (): void => {
+    if (closed) {
+      return
+    }
+
     const metrics: Metrics = _summarize();
     if (metrics) {
       log.debug('Start sending metrics data');
@@ -213,6 +218,7 @@ export const MetricsProcessor = (
     log.info('Closing MetricsProcessor');
     clearInterval(syncInterval);
     _send();
+    closed = true
     log.info('MetricsProcessor closed');
     infoMetricsThreadExited(log)
   };

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -24,6 +24,7 @@ import {
 } from './openapi';
 import { Options, Target } from './types';
 import { VERSION } from './version';
+import { infoMetricsSuccess, infoMetricsThreadExited, warnPostMetricsFailed } from "./sdk_codes";
 
 export enum MetricEvent {
   READY = 'metrics_ready',
@@ -184,6 +185,7 @@ export const MetricsProcessor = (
         .postMetrics(environment, cluster, metrics)
         .then((response) => {
           log.debug('Metrics server returns: ', response.status);
+          infoMetricsSuccess(log)
           if (response.status >= 400) {
             log.error(
               'Error while sending metrics data with status code: ',
@@ -192,6 +194,7 @@ export const MetricsProcessor = (
           }
         })
         .catch((error: Error) => {
+          warnPostMetricsFailed(`${error}`, log)
           log.debug('Metrics server returns error: ', error);
         });
     }
@@ -211,6 +214,7 @@ export const MetricsProcessor = (
     clearInterval(syncInterval);
     _send();
     log.info('MetricsProcessor closed');
+    infoMetricsThreadExited(log)
   };
 
   return {

--- a/src/polling.ts
+++ b/src/polling.ts
@@ -3,7 +3,7 @@ import { Options } from './types';
 import EventEmitter from 'events';
 import { Repository } from './repository';
 import { ConsoleLog } from './log';
-import { infoPollingStopped } from "./sdk_codes";
+import { infoPollingStopped } from './sdk_codes';
 
 export enum PollerEvent {
   READY = 'poller_ready',
@@ -43,7 +43,7 @@ export class PollingProcessor {
   private poll() {
     if (this.stopped) {
       this.log.info('PollingProcessor stopped');
-      infoPollingStopped(this.log)
+      infoPollingStopped(this.log);
       return;
     }
 
@@ -81,7 +81,7 @@ export class PollingProcessor {
         // we will check one more time if processor is stopped
         if (this.stopped) {
           this.log.info('PollingProcessor stopped');
-          infoPollingStopped(this.log)
+          infoPollingStopped(this.log);
           return;
         }
         pollAgain();

--- a/src/polling.ts
+++ b/src/polling.ts
@@ -3,6 +3,7 @@ import { Options } from './types';
 import EventEmitter from 'events';
 import { Repository } from './repository';
 import { ConsoleLog } from './log';
+import { infoPollingStopped } from "./sdk_codes";
 
 export enum PollerEvent {
   READY = 'poller_ready',
@@ -42,6 +43,7 @@ export class PollingProcessor {
   private poll() {
     if (this.stopped) {
       this.log.info('PollingProcessor stopped');
+      infoPollingStopped(this.log)
       return;
     }
 
@@ -79,6 +81,7 @@ export class PollingProcessor {
         // we will check one more time if processor is stopped
         if (this.stopped) {
           this.log.info('PollingProcessor stopped');
+          infoPollingStopped(this.log)
           return;
         }
         pollAgain();

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -27,8 +27,7 @@ const sdkCodes: SDKCodeMessages = {
   5002: 'SSE event received: ',
   5003: 'SSE retrying to connect in',
   5004: 'SSE stopped',
-  // SDK_EVAL_6xxx - these are hardcoded in `client.ts` as they
-  // are more complex
+  // SDK_EVAL_6xxx -
   6000: 'Evaluation successful: ',
   6001: 'Evaluation Failed, returning default variation: ',
   // SDK_METRICS_7xxx
@@ -36,7 +35,6 @@ const sdkCodes: SDKCodeMessages = {
   7001: 'Metrics thread exited',
   7002: 'Posting metrics failed, reason:',
   7003: 'Metrics posted successfully',
-  7004: 'Target metrics exceeded max size, remaining targets for this analytics interval will not be sent',
 };
 
 export function getSDKCodeMessage(key: number): string {
@@ -75,19 +73,16 @@ export function infoSDKAuthOK(logger: Logger): void {
   logger.info(sdkErrMsg(2000, ''));
 }
 
-export function infoPollingStopped(reason: string, logger: Logger): void {
-  logger.info(sdkErrMsg(4001, reason));
+export function infoPollingStopped(logger: Logger): void {
+  logger.info(sdkErrMsg(4001));
 }
 
 export function infoStreamConnected(logger: Logger): void {
   logger.info(sdkErrMsg(5000, ''));
 }
 
-export function infoStreamEventReceived(
-  eventJson: string,
-  logger: Logger,
-): void {
-  logger.info(sdkErrMsg(5002, eventJson));
+export function debugStreamEventReceived(logger: Logger): void {
+  logger.debug(sdkErrMsg(5002));
 }
 
 export function infoStreamStopped(logger: Logger): void {
@@ -103,10 +98,6 @@ export function infoMetricsThreadStarted(
 
 export function infoMetricsSuccess(logger: Logger): void {
   logger.info(sdkErrMsg(7003, ''));
-}
-
-export function infoMetricsTargetExceeded(logger: Logger): void {
-  logger.info(sdkErrMsg(7004, ''));
 }
 
 export function infoMetricsThreadExited(logger: Logger): void {

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -119,7 +119,7 @@ export function infoMetricsThreadExited(logger: Logger): void {
 }
 
 export function infoEvalSuccess(result: string, flagIdentifier: string, target: Target, logger: Logger): void {
-  logger.info(sdkErrMsg(6000, `result=${result}, flag identifier=${flagIdentifier}, target=${JSON.stringify(target)}`))
+  logger.debug(sdkErrMsg(6000, `result=${result}, flag identifier=${flagIdentifier}, target=${JSON.stringify(target)}`))
 }
 
 export function warnAuthFailedSrvDefaults(logger: Logger): void {

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -1,5 +1,5 @@
 import { Logger } from './log';
-import { Target } from "./types";
+import { Target } from './types';
 
 interface SDKCodeMessages {
   [key: number]: string;
@@ -28,8 +28,10 @@ const sdkCodes: SDKCodeMessages = {
   5002: 'SSE event received: ',
   5003: 'SSE retrying to connect in',
   5004: 'SSE stopped',
-  // SDK_EVAL_6xxx - these are hardcoded in `variation.py` as they
+  // SDK_EVAL_6xxx - these are hardcoded in `client.ts` as they
   // are more complex
+  6000: 'Evaluation successful: ',
+  6001: 'Evaluation Failed, returning default variation: ',
   // SDK_METRICS_7xxx
   7000: 'Metrics thread started with request interval:',
   7001: 'Metrics thread exited',
@@ -46,13 +48,9 @@ export function getSDKCodeMessage(key: number): string {
   }
 }
 
-export function sdkErrMsg(
-  errorCode: number,
-  appendText = '',
-): string {
-  return `SDKCODE:${errorCode}: ${getSDKCodeMessage(
-    errorCode
-  )} ${appendText}`;}
+export function sdkErrMsg(errorCode: number, appendText = ''): string {
+  return `SDKCODE:${errorCode}: ${getSDKCodeMessage(errorCode)} ${appendText}`;
+}
 
 export function warnMissingSDKKey(logger: Logger): void {
   logger.warn(sdkErrMsg(1002, ''));
@@ -90,7 +88,10 @@ export function infoStreamConnected(logger: Logger): void {
   logger.info(sdkErrMsg(5000, ''));
 }
 
-export function infoStreamEventReceived(eventJson: string, logger: Logger): void {
+export function infoStreamEventReceived(
+  eventJson: string,
+  logger: Logger,
+): void {
   logger.info(sdkErrMsg(5002, eventJson));
 }
 
@@ -98,7 +99,10 @@ export function infoStreamStopped(logger: Logger): void {
   logger.info(sdkErrMsg(5004, ''));
 }
 
-export function infoMetricsThreadStarted(interval: number, logger: Logger): void {
+export function infoMetricsThreadStarted(
+  interval: number,
+  logger: Logger,
+): void {
   logger.info(sdkErrMsg(7000, `${interval}`));
 }
 
@@ -114,8 +118,8 @@ export function infoMetricsThreadExited(logger: Logger): void {
   logger.info(sdkErrMsg(7001, ''));
 }
 
-export function infoEvalSuccess(logger: Logger): void {
-  logger.info(sdkErrMsg(6000, ''));
+export function infoEvalSuccess(result: string, flagIdentifier: string, target: Target, logger: Logger): void {
+  logger.info(sdkErrMsg(6000, `result=${result}, flag identifier=${flagIdentifier}, target=${JSON.stringify(target)}`))
 }
 
 export function warnAuthFailedSrvDefaults(logger: Logger): void {
@@ -133,12 +137,11 @@ export function warnAuthFailedExceedRetries(logger: Logger): void {
 export function warnAuthRetrying(
   attempt: number,
   error: string,
-  logger: Logger
+  logger: Logger,
 ): void {
-  logger.warn(sdkErrMsg(
-    2002,
-    `attempt ${attempt}, got error: ${error}, Retrying ...`
-  ));
+  logger.warn(
+    sdkErrMsg(2002, `attempt ${attempt}, got error: ${error}, Retrying ...`),
+  );
 }
 
 export function warnStreamDisconnected(reason: string, logger: Logger): void {
@@ -157,10 +160,9 @@ export function warnDefaultVariationServed(
   flag: string,
   target: Target,
   defaultValue: string,
-  logger: Logger
+  logger: Logger,
 ): void {
-  logger.warn(sdkErrMsg(
-    6001,
-    `flag=${flag}, target=${target}, default=${defaultValue}`,
-  ));
+  logger.warn(
+    sdkErrMsg(6001, `flag=${flag}, target=${JSON.stringify(target)}, default=${defaultValue}`),
+  );
 }

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -1,4 +1,5 @@
 import { Logger } from './log';
+import { Target } from "./types";
 
 interface SDKCodeMessages {
   [key: number]: string;
@@ -154,7 +155,7 @@ export function warnPostMetricsFailed(reason: string, logger: Logger): void {
 
 export function warnDefaultVariationServed(
   flag: string,
-  target: string,
+  target: Target,
   defaultValue: string,
   logger: Logger
 ): void {

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -37,7 +37,7 @@ const sdkCodes: SDKCodeMessages = {
   7004: 'Target metrics exceeded max size, remaining targets for this analytics interval will not be sent',
 };
 
-function getSDKCodeMessage(key: number): string {
+export function getSDKCodeMessage(key: number): string {
   if (key in sdkCodes) {
     return sdkCodes[key];
   } else {
@@ -45,91 +45,91 @@ function getSDKCodeMessage(key: number): string {
   }
 }
 
-function sdkErrMsg(
+export function sdkErrMsg(
   errorCode: number,
   appendText = '',
-): String {
+): string {
   return `SDKCODE:${errorCode}: ${getSDKCodeMessage(
     errorCode
   )} ${appendText}`;}
 
-function warnMissingSDKKey(logger: Logger): void {
+export function warnMissingSDKKey(logger: Logger): void {
   logger.warn(sdkErrMsg(1002, ''));
 }
 
-function infoPollStarted(durationSec: number, logger: Logger): void {
+export function infoPollStarted(durationSec: number, logger: Logger): void {
   logger.info(sdkErrMsg(4000, `${durationSec * 1000}`));
 }
 
-function infoSDKInitOK(logger: Logger): void {
+export function infoSDKInitOK(logger: Logger): void {
   logger.info(sdkErrMsg(1000, ''));
 }
 
-function infoSDKInitWaiting(logger: Logger): void {
+export function infoSDKInitWaiting(logger: Logger): void {
   logger.info(sdkErrMsg(1003, ''));
 }
 
-function infoSDKStartClose(logger: Logger): void {
+export function infoSDKStartClose(logger: Logger): void {
   logger.info(sdkErrMsg(3000, ''));
 }
 
-function infoSDKCloseSuccess(logger: Logger): void {
+export function infoSDKCloseSuccess(logger: Logger): void {
   logger.info(sdkErrMsg(3001, ''));
 }
 
-function infoSDKAuthOK(logger: Logger): void {
+export function infoSDKAuthOK(logger: Logger): void {
   logger.info(sdkErrMsg(2000, ''));
 }
 
-function infoPollingStopped(reason: string, logger: Logger): void {
+export function infoPollingStopped(reason: string, logger: Logger): void {
   logger.info(sdkErrMsg(4001, reason));
 }
 
-function infoStreamConnected(logger: Logger): void {
+export function infoStreamConnected(logger: Logger): void {
   logger.info(sdkErrMsg(5000, ''));
 }
 
-function infoStreamEventReceived(eventJson: string, logger: Logger): void {
+export function infoStreamEventReceived(eventJson: string, logger: Logger): void {
   logger.info(sdkErrMsg(5002, eventJson));
 }
 
-function infoStreamStopped(logger: Logger): void {
+export function infoStreamStopped(logger: Logger): void {
   logger.info(sdkErrMsg(5004, ''));
 }
 
-function infoMetricsThreadStarted(interval: number, logger: Logger): void {
+export function infoMetricsThreadStarted(interval: number, logger: Logger): void {
   logger.info(sdkErrMsg(7000, `${interval}`));
 }
 
-function infoMetricsSuccess(logger: Logger): void {
+export function infoMetricsSuccess(logger: Logger): void {
   logger.info(sdkErrMsg(7003, ''));
 }
 
-function infoMetricsTargetExceeded(logger: Logger): void {
+export function infoMetricsTargetExceeded(logger: Logger): void {
   logger.info(sdkErrMsg(7004, ''));
 }
 
-function infoMetricsThreadExited(logger: Logger): void {
+export function infoMetricsThreadExited(logger: Logger): void {
   logger.info(sdkErrMsg(7001, ''));
 }
 
-function infoEvalSuccess(logger: Logger): void {
+export function infoEvalSuccess(logger: Logger): void {
   logger.info(sdkErrMsg(6000, ''));
 }
 
-function warnAuthFailedSrvDefaults(logger: Logger): void {
+export function warnAuthFailedSrvDefaults(logger: Logger): void {
   logger.warn(sdkErrMsg(2001, ''));
 }
 
-function warnFailedInitAuthError(logger: Logger): void {
+export function warnFailedInitAuthError(logger: Logger): void {
   logger.warn(sdkErrMsg(1001, ''));
 }
 
-function warnAuthFailedExceedRetries(logger: Logger): void {
+export function warnAuthFailedExceedRetries(logger: Logger): void {
   logger.warn(sdkErrMsg(2003, ''));
 }
 
-function warnAuthRetrying(
+export function warnAuthRetrying(
   attempt: number,
   error: string,
   logger: Logger
@@ -140,19 +140,19 @@ function warnAuthRetrying(
   ));
 }
 
-function warnStreamDisconnected(reason: string, logger: Logger): void {
+export function warnStreamDisconnected(reason: string, logger: Logger): void {
   logger.warn(sdkErrMsg(5001, reason));
 }
 
-function warnStreamRetrying(seconds: number, logger: Logger): void {
+export function warnStreamRetrying(seconds: number, logger: Logger): void {
   logger.warn(sdkErrMsg(5003, `${seconds}`));
 }
 
-function warnPostMetricsFailed(reason: string, logger: Logger): void {
+export function warnPostMetricsFailed(reason: string, logger: Logger): void {
   logger.warn(sdkErrMsg(7002, reason));
 }
 
-function warnDefaultVariationServed(
+export function warnDefaultVariationServed(
   flag: string,
   target: string,
   defaultValue: string,

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -32,7 +32,7 @@ const sdkCodes: SDKCodeMessages = {
   6001: 'Evaluation Failed, returning default variation: ',
   // SDK_METRICS_7xxx
   7000: 'Metrics thread started with request interval:',
-  7001: 'Metrics thread exited',
+  7001: 'Metrics stopped',
   7002: 'Posting metrics failed, reason:',
   7003: 'Metrics posted successfully',
 };

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -15,7 +15,7 @@ const sdkCodes: Record<number, string> = {
   3000: 'Closing SDK',
   3001: 'SDK Closed successfully',
   // SDK_POLL_4xxx
-  4000: 'Polling started, intervalMs:',
+  4000: 'Polling started, interval:',
   4001: 'Polling stopped',
   // SDK_STREAM_5xxx
   5000: 'SSE stream successfully connected',
@@ -41,16 +41,22 @@ function getSDKCodeMessage(key: number): string {
   }
 }
 
-function getSdkErrMsg(errorCode: number, appendText = ''): string {
-  return `SDKCODE:${errorCode}: ${getSDKCodeMessage(errorCode)} ${appendText}`;
+function getSdkErrMsg(
+  errorCode: number,
+  appendText: string | number = '',
+): string {
+  const appendedText = String(appendText);
+  return `SDKCODE:${errorCode}: ${getSDKCodeMessage(
+    errorCode,
+  )} ${appendedText}`;
 }
 
 export function warnMissingSDKKey(logger: Logger): void {
   logger.warn(getSdkErrMsg(1002));
 }
 
-export function infoPollStarted(durationSec: number, logger: Logger): void {
-  logger.info(getSdkErrMsg(4000, `${durationSec * 1000}`));
+export function infoPollStarted(durationMS: number, logger: Logger): void {
+  logger.info(getSdkErrMsg(4000, durationMS / 1000 + ' seconds'));
 }
 
 export function infoSDKInitOK(logger: Logger): void {
@@ -89,7 +95,7 @@ export function infoMetricsThreadStarted(
   interval: number,
   logger: Logger,
 ): void {
-  logger.info(getSdkErrMsg(7000, `${interval}`));
+  logger.info(getSdkErrMsg(7000, interval / 1000 + ' seconds'));
 }
 
 export function infoMetricsSuccess(logger: Logger): void {
@@ -134,7 +140,10 @@ export function warnAuthRetrying(
   logger: Logger,
 ): void {
   logger.warn(
-    getSdkErrMsg(2002, `attempt=${attempt}, error=${error}, continue retrying=true`),
+    getSdkErrMsg(
+      2002,
+      `attempt=${attempt}, error=${error}, continue retrying=true`,
+    ),
   );
 }
 

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -9,7 +9,7 @@ const sdkCodes: Record<number, string> = {
   // SDK_AUTH_2xxx
   2000: 'Authentication was successful',
   2001: 'Authentication failed with a non-recoverable error',
-  2002: 'Authentication attempt',
+  2002: 'Authentication attempt failed:',
   2003: 'Authentication failed and max retries have been exceeded',
   // SDK_CLOSE_3xxx
   3000: 'Closing SDK',
@@ -134,7 +134,7 @@ export function warnAuthRetrying(
   logger: Logger,
 ): void {
   logger.warn(
-    getSdkErrMsg(2002, `attempt ${attempt}, got error: ${error}, Retrying ...`),
+    getSdkErrMsg(2002, `attempt=${attempt}, error=${error}, continue retrying=true`),
   );
 }
 

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -1,0 +1,165 @@
+import { Logger } from './log';
+
+interface SDKCodeMessages {
+  [key: number]: string;
+}
+
+const sdkCodes: SDKCodeMessages = {
+  // SDK_INIT_1xxx
+  1000: 'The SDK has successfully initialized',
+  1001: 'The SDK has failed to initialize due to an authentication error - defaults will be served',
+  1002: 'The SDK has failed to initialize due to a missing or empty API key - defaults will be served',
+  1003: 'The SDK is waiting for initialization to complete',
+  // SDK_AUTH_2xxx
+  2000: 'Authentication was successful',
+  2001: 'Authentication failed with a non-recoverable error',
+  2002: 'Authentication attempt',
+  2003: 'Authentication failed and max retries have been exceeded',
+  // SDK_CLOSE_3xxx
+  3000: 'Closing SDK',
+  3001: 'SDK Closed successfully',
+  // SDK_POLL_4xxx
+  4000: 'Polling started, intervalMs:',
+  4001: 'Polling stopped, reason:',
+  // SDK_STREAM_5xxx
+  5000: 'SSE stream successfully connected',
+  5001: 'SSE stream disconnected, reason:',
+  5002: 'SSE event received: ',
+  5003: 'SSE retrying to connect in',
+  5004: 'SSE stopped',
+  // SDK_EVAL_6xxx - these are hardcoded in `variation.py` as they
+  // are more complex
+  // SDK_METRICS_7xxx
+  7000: 'Metrics thread started with request interval:',
+  7001: 'Metrics thread exited',
+  7002: 'Posting metrics failed, reason:',
+  7003: 'Metrics posted successfully',
+  7004: 'Target metrics exceeded max size, remaining targets for this analytics interval will not be sent',
+};
+
+function getSDKCodeMessage(key: number): string {
+  if (key in sdkCodes) {
+    return sdkCodes[key];
+  } else {
+    return 'Unknown SDK code';
+  }
+}
+
+function sdkErrMsg(
+  errorCode: number,
+  appendText = '',
+): String {
+  return `SDKCODE:${errorCode}: ${getSDKCodeMessage(
+    errorCode
+  )} ${appendText}`;}
+
+function warnMissingSDKKey(logger: Logger): void {
+  logger.warn(sdkErrMsg(1002, ''));
+}
+
+function infoPollStarted(durationSec: number, logger: Logger): void {
+  logger.info(sdkErrMsg(4000, `${durationSec * 1000}`));
+}
+
+function infoSDKInitOK(logger: Logger): void {
+  logger.info(sdkErrMsg(1000, ''));
+}
+
+function infoSDKInitWaiting(logger: Logger): void {
+  logger.info(sdkErrMsg(1003, ''));
+}
+
+function infoSDKStartClose(logger: Logger): void {
+  logger.info(sdkErrMsg(3000, ''));
+}
+
+function infoSDKCloseSuccess(logger: Logger): void {
+  logger.info(sdkErrMsg(3001, ''));
+}
+
+function infoSDKAuthOK(logger: Logger): void {
+  logger.info(sdkErrMsg(2000, ''));
+}
+
+function infoPollingStopped(reason: string, logger: Logger): void {
+  logger.info(sdkErrMsg(4001, reason));
+}
+
+function infoStreamConnected(logger: Logger): void {
+  logger.info(sdkErrMsg(5000, ''));
+}
+
+function infoStreamEventReceived(eventJson: string, logger: Logger): void {
+  logger.info(sdkErrMsg(5002, eventJson));
+}
+
+function infoStreamStopped(logger: Logger): void {
+  logger.info(sdkErrMsg(5004, ''));
+}
+
+function infoMetricsThreadStarted(interval: number, logger: Logger): void {
+  logger.info(sdkErrMsg(7000, `${interval}`));
+}
+
+function infoMetricsSuccess(logger: Logger): void {
+  logger.info(sdkErrMsg(7003, ''));
+}
+
+function infoMetricsTargetExceeded(logger: Logger): void {
+  logger.info(sdkErrMsg(7004, ''));
+}
+
+function infoMetricsThreadExited(logger: Logger): void {
+  logger.info(sdkErrMsg(7001, ''));
+}
+
+function infoEvalSuccess(logger: Logger): void {
+  logger.info(sdkErrMsg(6000, ''));
+}
+
+function warnAuthFailedSrvDefaults(logger: Logger): void {
+  logger.warn(sdkErrMsg(2001, ''));
+}
+
+function warnFailedInitAuthError(logger: Logger): void {
+  logger.warn(sdkErrMsg(1001, ''));
+}
+
+function warnAuthFailedExceedRetries(logger: Logger): void {
+  logger.warn(sdkErrMsg(2003, ''));
+}
+
+function warnAuthRetrying(
+  attempt: number,
+  error: string,
+  logger: Logger
+): void {
+  logger.warn(sdkErrMsg(
+    2002,
+    `attempt ${attempt}, got error: ${error}, Retrying ...`
+  ));
+}
+
+function warnStreamDisconnected(reason: string, logger: Logger): void {
+  logger.warn(sdkErrMsg(5001, reason));
+}
+
+function warnStreamRetrying(seconds: number, logger: Logger): void {
+  logger.warn(sdkErrMsg(5003, `${seconds}`));
+}
+
+function warnPostMetricsFailed(reason: string, logger: Logger): void {
+  logger.warn(sdkErrMsg(7002, reason));
+}
+
+function warnDefaultVariationServed(
+  flag: string,
+  target: string,
+  defaultValue: string,
+  logger: Logger
+): void {
+  logger.warn(sdkErrMsg(
+    6001,
+    `flag=${flag}, target=${target}, default=${defaultValue}`,
+  ));
+}

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -118,8 +118,20 @@ export function infoMetricsThreadExited(logger: Logger): void {
   logger.info(sdkErrMsg(7001, ''));
 }
 
-export function infoEvalSuccess(result: string, flagIdentifier: string, target: Target, logger: Logger): void {
-  logger.debug(sdkErrMsg(6000, `result=${result}, flag identifier=${flagIdentifier}, target=${JSON.stringify(target)}`))
+export function debugEvalSuccess(
+  result: string,
+  flagIdentifier: string,
+  target: Target,
+  logger: Logger,
+): void {
+  logger.debug(
+    sdkErrMsg(
+      6000,
+      `result=${result}, flag identifier=${flagIdentifier}, target=${JSON.stringify(
+        target,
+      )}`,
+    ),
+  );
 }
 
 export function warnAuthFailedSrvDefaults(logger: Logger): void {
@@ -163,6 +175,11 @@ export function warnDefaultVariationServed(
   logger: Logger,
 ): void {
   logger.warn(
-    sdkErrMsg(6001, `default variation used=${defaultValue}, flag=${flag}, target=${JSON.stringify(target)}`),
+    sdkErrMsg(
+      6001,
+      `default variation used=${defaultValue}, flag=${flag}, target=${JSON.stringify(
+        target,
+      )}`,
+    ),
   );
 }

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -50,7 +50,7 @@ export function sdkErrMsg(errorCode: number, appendText = ''): string {
 }
 
 export function warnMissingSDKKey(logger: Logger): void {
-  logger.warn(sdkErrMsg(1002, ''));
+  logger.warn(sdkErrMsg(1002));
 }
 
 export function infoPollStarted(durationSec: number, logger: Logger): void {

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -45,10 +45,9 @@ function getSdkErrMsg(
   errorCode: number,
   appendText: string | number = '',
 ): string {
-  const appendedText = String(appendText);
   return `SDKCODE:${errorCode}: ${getSDKCodeMessage(
     errorCode,
-  )} ${appendedText}`;
+  )} ${appendText}`;
 }
 
 export function warnMissingSDKKey(logger: Logger): void {

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -46,58 +46,58 @@ function getSdkErrMsg(errorCode: number, appendText = ''): string {
 }
 
 export function warnMissingSDKKey(logger: Logger): void {
-  logger.warn(sdkErrMsg(1002));
+  logger.warn(getSdkErrMsg(1002));
 }
 
 export function infoPollStarted(durationSec: number, logger: Logger): void {
-  logger.info(sdkErrMsg(4000, `${durationSec * 1000}`));
+  logger.info(getSdkErrMsg(4000, `${durationSec * 1000}`));
 }
 
 export function infoSDKInitOK(logger: Logger): void {
-  logger.info(sdkErrMsg(1000, ''));
+  logger.info(getSdkErrMsg(1000, ''));
 }
 
 export function infoSDKStartClose(logger: Logger): void {
-  logger.info(sdkErrMsg(3000, ''));
+  logger.info(getSdkErrMsg(3000, ''));
 }
 
 export function infoSDKCloseSuccess(logger: Logger): void {
-  logger.info(sdkErrMsg(3001, ''));
+  logger.info(getSdkErrMsg(3001, ''));
 }
 
 export function infoSDKAuthOK(logger: Logger): void {
-  logger.info(sdkErrMsg(2000, ''));
+  logger.info(getSdkErrMsg(2000, ''));
 }
 
 export function infoPollingStopped(logger: Logger): void {
-  logger.info(sdkErrMsg(4001));
+  logger.info(getSdkErrMsg(4001));
 }
 
 export function infoStreamConnected(logger: Logger): void {
-  logger.info(sdkErrMsg(5000, ''));
+  logger.info(getSdkErrMsg(5000, ''));
 }
 
 export function debugStreamEventReceived(logger: Logger): void {
-  logger.debug(sdkErrMsg(5002));
+  logger.debug(getSdkErrMsg(5002));
 }
 
 export function infoStreamStopped(logger: Logger): void {
-  logger.info(sdkErrMsg(5004, ''));
+  logger.info(getSdkErrMsg(5004, ''));
 }
 
 export function infoMetricsThreadStarted(
   interval: number,
   logger: Logger,
 ): void {
-  logger.info(sdkErrMsg(7000, `${interval}`));
+  logger.info(getSdkErrMsg(7000, `${interval}`));
 }
 
 export function infoMetricsSuccess(logger: Logger): void {
-  logger.info(sdkErrMsg(7003, ''));
+  logger.info(getSdkErrMsg(7003, ''));
 }
 
 export function infoMetricsThreadExited(logger: Logger): void {
-  logger.info(sdkErrMsg(7001, ''));
+  logger.info(getSdkErrMsg(7001, ''));
 }
 
 export function debugEvalSuccess(
@@ -107,7 +107,7 @@ export function debugEvalSuccess(
   logger: Logger,
 ): void {
   logger.debug(
-    sdkErrMsg(
+    getSdkErrMsg(
       6000,
       `result=${result}, flag identifier=${flagIdentifier}, target=${JSON.stringify(
         target,
@@ -117,15 +117,15 @@ export function debugEvalSuccess(
 }
 
 export function warnAuthFailedSrvDefaults(logger: Logger): void {
-  logger.warn(sdkErrMsg(2001, ''));
+  logger.warn(getSdkErrMsg(2001, ''));
 }
 
 export function warnFailedInitAuthError(logger: Logger): void {
-  logger.warn(sdkErrMsg(1001, ''));
+  logger.warn(getSdkErrMsg(1001, ''));
 }
 
 export function warnAuthFailedExceedRetries(logger: Logger): void {
-  logger.warn(sdkErrMsg(2003, ''));
+  logger.warn(getSdkErrMsg(2003, ''));
 }
 
 export function warnAuthRetrying(
@@ -134,20 +134,20 @@ export function warnAuthRetrying(
   logger: Logger,
 ): void {
   logger.warn(
-    sdkErrMsg(2002, `attempt ${attempt}, got error: ${error}, Retrying ...`),
+    getSdkErrMsg(2002, `attempt ${attempt}, got error: ${error}, Retrying ...`),
   );
 }
 
 export function warnStreamDisconnected(reason: string, logger: Logger): void {
-  logger.warn(sdkErrMsg(5001, reason));
+  logger.warn(getSdkErrMsg(5001, reason));
 }
 
 export function warnStreamRetrying(seconds: number, logger: Logger): void {
-  logger.warn(sdkErrMsg(5003, `${seconds}`));
+  logger.warn(getSdkErrMsg(5003, `${seconds}`));
 }
 
 export function warnPostMetricsFailed(reason: string, logger: Logger): void {
-  logger.warn(sdkErrMsg(7002, reason));
+  logger.warn(getSdkErrMsg(7002, reason));
 }
 
 export function warnDefaultVariationServed(
@@ -157,7 +157,7 @@ export function warnDefaultVariationServed(
   logger: Logger,
 ): void {
   logger.warn(
-    sdkErrMsg(
+    getSdkErrMsg(
       6001,
       `default variation used=${defaultValue}, flag=${flag}, target=${JSON.stringify(
         target,

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -1,11 +1,7 @@
 import { Logger } from './log';
 import { Target } from './types';
 
-interface SDKCodeMessages {
-  [key: number]: string;
-}
-
-const sdkCodes: SDKCodeMessages = {
+const sdkCodes: Record<number, string> = {
   // SDK_INIT_1xxx
   1000: 'The SDK has successfully initialized',
   1001: 'The SDK has failed to initialize due to an authentication error - defaults will be served',

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -10,7 +10,6 @@ const sdkCodes: SDKCodeMessages = {
   1000: 'The SDK has successfully initialized',
   1001: 'The SDK has failed to initialize due to an authentication error - defaults will be served',
   1002: 'The SDK has failed to initialize due to a missing or empty API key - defaults will be served',
-  1003: 'The SDK is waiting for initialization to complete',
   // SDK_AUTH_2xxx
   2000: 'Authentication was successful',
   2001: 'Authentication failed with a non-recoverable error',
@@ -62,10 +61,6 @@ export function infoPollStarted(durationSec: number, logger: Logger): void {
 
 export function infoSDKInitOK(logger: Logger): void {
   logger.info(sdkErrMsg(1000, ''));
-}
-
-export function infoSDKInitWaiting(logger: Logger): void {
-  logger.info(sdkErrMsg(1003, ''));
 }
 
 export function infoSDKStartClose(logger: Logger): void {

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -163,6 +163,6 @@ export function warnDefaultVariationServed(
   logger: Logger,
 ): void {
   logger.warn(
-    sdkErrMsg(6001, `, default value=${defaultValue}, flag=${flag}, target=${JSON.stringify(target)}`),
+    sdkErrMsg(6001, `default value=${defaultValue}, flag=${flag}, target=${JSON.stringify(target)}`),
   );
 }

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -16,7 +16,7 @@ const sdkCodes: Record<number, string> = {
   3001: 'SDK Closed successfully',
   // SDK_POLL_4xxx
   4000: 'Polling started, intervalMs:',
-  4001: 'Polling stopped, reason:',
+  4001: 'Polling stopped',
   // SDK_STREAM_5xxx
   5000: 'SSE stream successfully connected',
   5001: 'SSE stream disconnected, reason:',

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -163,6 +163,6 @@ export function warnDefaultVariationServed(
   logger: Logger,
 ): void {
   logger.warn(
-    sdkErrMsg(6001, `flag=${flag}, target=${JSON.stringify(target)}, default=${defaultValue}`),
+    sdkErrMsg(6001, `, default value=${defaultValue}, flag=${flag}, target=${JSON.stringify(target)}`),
   );
 }

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -20,7 +20,7 @@ const sdkCodes: Record<number, string> = {
   // SDK_STREAM_5xxx
   5000: 'SSE stream successfully connected',
   5001: 'SSE stream disconnected, reason:',
-  5002: 'SSE event received: ',
+  5002: 'SSE event received',
   5003: 'SSE retrying to connect in',
   5004: 'SSE stopped',
   // SDK_EVAL_6xxx -

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -54,19 +54,19 @@ export function infoPollStarted(durationSec: number, logger: Logger): void {
 }
 
 export function infoSDKInitOK(logger: Logger): void {
-  logger.info(getSdkErrMsg(1000, ''));
+  logger.info(getSdkErrMsg(1000));
 }
 
 export function infoSDKStartClose(logger: Logger): void {
-  logger.info(getSdkErrMsg(3000, ''));
+  logger.info(getSdkErrMsg(3000));
 }
 
 export function infoSDKCloseSuccess(logger: Logger): void {
-  logger.info(getSdkErrMsg(3001, ''));
+  logger.info(getSdkErrMsg(3001));
 }
 
 export function infoSDKAuthOK(logger: Logger): void {
-  logger.info(getSdkErrMsg(2000, ''));
+  logger.info(getSdkErrMsg(2000));
 }
 
 export function infoPollingStopped(logger: Logger): void {
@@ -74,7 +74,7 @@ export function infoPollingStopped(logger: Logger): void {
 }
 
 export function infoStreamConnected(logger: Logger): void {
-  logger.info(getSdkErrMsg(5000, ''));
+  logger.info(getSdkErrMsg(5000));
 }
 
 export function debugStreamEventReceived(logger: Logger): void {
@@ -82,7 +82,7 @@ export function debugStreamEventReceived(logger: Logger): void {
 }
 
 export function infoStreamStopped(logger: Logger): void {
-  logger.info(getSdkErrMsg(5004, ''));
+  logger.info(getSdkErrMsg(5004));
 }
 
 export function infoMetricsThreadStarted(
@@ -93,11 +93,11 @@ export function infoMetricsThreadStarted(
 }
 
 export function infoMetricsSuccess(logger: Logger): void {
-  logger.info(getSdkErrMsg(7003, ''));
+  logger.info(getSdkErrMsg(7003));
 }
 
 export function infoMetricsThreadExited(logger: Logger): void {
-  logger.info(getSdkErrMsg(7001, ''));
+  logger.info(getSdkErrMsg(7001));
 }
 
 export function debugEvalSuccess(
@@ -117,15 +117,15 @@ export function debugEvalSuccess(
 }
 
 export function warnAuthFailedSrvDefaults(logger: Logger): void {
-  logger.warn(getSdkErrMsg(2001, ''));
+  logger.warn(getSdkErrMsg(2001));
 }
 
 export function warnFailedInitAuthError(logger: Logger): void {
-  logger.warn(getSdkErrMsg(1001, ''));
+  logger.warn(getSdkErrMsg(1001));
 }
 
 export function warnAuthFailedExceedRetries(logger: Logger): void {
-  logger.warn(getSdkErrMsg(2003, ''));
+  logger.warn(getSdkErrMsg(2003));
 }
 
 export function warnAuthRetrying(

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -45,7 +45,7 @@ function getSDKCodeMessage(key: number): string {
   }
 }
 
-export function sdkErrMsg(errorCode: number, appendText = ''): string {
+function getSdkErrMsg(errorCode: number, appendText = ''): string {
   return `SDKCODE:${errorCode}: ${getSDKCodeMessage(errorCode)} ${appendText}`;
 }
 

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -163,6 +163,6 @@ export function warnDefaultVariationServed(
   logger: Logger,
 ): void {
   logger.warn(
-    sdkErrMsg(6001, `default value=${defaultValue}, flag=${flag}, target=${JSON.stringify(target)}`),
+    sdkErrMsg(6001, `default variation used=${defaultValue}, flag=${flag}, target=${JSON.stringify(target)}`),
   );
 }

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -37,7 +37,7 @@ const sdkCodes: SDKCodeMessages = {
   7003: 'Metrics posted successfully',
 };
 
-export function getSDKCodeMessage(key: number): string {
+function getSDKCodeMessage(key: number): string {
   if (key in sdkCodes) {
     return sdkCodes[key];
   } else {

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -7,7 +7,12 @@ import { ConsoleLog } from './log';
 
 import https, { RequestOptions } from 'https';
 import http, { ClientRequest } from 'http';
-import { debugStreamEventReceived, infoStreamStopped, warnStreamDisconnected, warnStreamRetrying } from "./sdk_codes";
+import {
+  debugStreamEventReceived,
+  infoStreamStopped,
+  warnStreamDisconnected,
+  warnStreamRetrying,
+} from './sdk_codes';
 
 type FetchFunction = (
   identifier: string,
@@ -138,7 +143,7 @@ export class StreamProcessor {
 
         res
           .on('data', (data) => {
-            debugStreamEventReceived(this.log)
+            debugStreamEventReceived(this.log);
             this.processData(data);
           })
           .on('close', () => {
@@ -235,6 +240,6 @@ export class StreamProcessor {
 
     this.eventBus.emit(StreamEvent.DISCONNECTED);
     this.log.info('StreamProcessor closed');
-    infoStreamStopped(this.log)
+    infoStreamStopped(this.log);
   }
 }

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -7,6 +7,7 @@ import { ConsoleLog } from './log';
 
 import https, { RequestOptions } from 'https';
 import http, { ClientRequest } from 'http';
+import { debugStreamEventReceived, infoStreamStopped, warnStreamDisconnected, warnStreamRetrying } from "./sdk_codes";
 
 type FetchFunction = (
   identifier: string,
@@ -88,7 +89,8 @@ export class StreamProcessor {
         this.retryAttempt += 1;
 
         const delayMs = this.getRandomRetryDelayMs();
-        this.log.warn(`SSE disconnected: ${msg} will retry in ${delayMs}ms`);
+        warnStreamDisconnected(msg, this.log);
+        warnStreamRetrying(delayMs, this.log);
         this.readyState = StreamProcessor.RETRYING;
         this.eventBus.emit(StreamEvent.RETRYING);
 
@@ -135,7 +137,10 @@ export class StreamProcessor {
         onConnected();
 
         res
-          .on('data', (data) => this.processData(data))
+          .on('data', (data) => {
+            debugStreamEventReceived(this.log)
+            this.processData(data);
+          })
           .on('close', () => {
             onFailed('SSE stream closed');
           });
@@ -230,5 +235,6 @@ export class StreamProcessor {
 
     this.eventBus.emit(StreamEvent.DISCONNECTED);
     this.log.info('StreamProcessor closed');
+    infoStreamStopped(this.log)
   }
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.3.0';
+export const VERSION = "1.3.0";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "1.2.17";
+export const VERSION = '1.3.0';


### PR DESCRIPTION
# What
This PR focuses on three changes

1. If the SDK fails authentication, then the SDK will not attempt to start any services (which results in a crash) and will serve default variations to users. 

2. Adds a list of SDK codes we are rolling out across SDKs - see https://harness.atlassian.net/wiki/spaces/FFM/pages/21356052573/SDK+Codes 

3. We saw an issue reported by a customer that the `environment` claim was missing from the auth JWT. This adds some validation and logging for that rare scenario. 

# Testing
Manual: 

1. SDK initialises and serves the expected flag variations 
2. SDK fails to initialise due to auth error or falsey API key and continues to to serve defaults
3. SDK Codes are logged correctly - I've included unit tests for these just to make sure all that code is tested.
4. Valid JWT claims don't cause the SDK to stop auth