### PR TITLE
FFM-9055 Emit failed event if auth fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,11 @@ const { Client, Event } = require('@harnessio/ff-nodejs-server-sdk');
     },
   };
 
-  await client.waitForInitialization();
+  try {
+    await client.waitForInitialization();
+  } catch (e) {
+    console.log("Error when authenticating Feature Flags client: " + e)
+  }
 
   try {
     // Log the state of the flag every 10 seconds

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-nodejs-server-sdk",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "bundleDependencies": [
         "axios",
         "eventsource",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Feature flags SDK for NodeJS environments",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/src/client.ts
+++ b/src/client.ts
@@ -255,7 +255,7 @@ export default class Client {
           this.eventBus.once(Event.READY, () => {
             setTimeout(() => resolve(this), 0);
           });
-          // TODO - we can return the rejection here, live I've done, which will
+          // TODO - we can return the rejection here, live it's already doing, which will
           // mean users have to surround this function with a try-catch or `then`
           // and do error handling. Or we can just return the resolve here. Will
           // discuss in PR.

--- a/src/client.ts
+++ b/src/client.ts
@@ -255,6 +255,10 @@ export default class Client {
           this.eventBus.once(Event.READY, () => {
             setTimeout(() => resolve(this), 0);
           });
+          // TODO - we can return the rejection here, live I've done, which will
+          // mean users have to surround this function with a try-catch or `then`
+          // and do error handling. Or we can just return the resolve here. Will
+          // discuss in PR.
           this.eventBus.once(Event.FAILED, reject);
         });
       }

--- a/src/client.ts
+++ b/src/client.ts
@@ -236,7 +236,7 @@ export default class Client {
       console.error('Error while authenticating, err: ', error);
       warnAuthFailedSrvDefaults(this.log);
       warnFailedInitAuthError(this.log);
-      this.eventBus.emit(Event.FAILED);
+      this.eventBus.emit(Event.FAILED, error);
     }
   }
 
@@ -245,20 +245,13 @@ export default class Client {
       if (this.initialized) {
         this.waitForInitializePromise = Promise.resolve(this);
         infoSDKInitOK(this.log);
-        // We unblock the call even if initialization has failed. We've
-        // already warned the user that initialization has failed and that
-        // defaults will be served
       } else if (!this.initialized && this.failure) {
-        this.waitForInitializePromise = Promise.resolve(this);
+        this.waitForInitializePromise = Promise.reject(this);
       } else {
         this.waitForInitializePromise = new Promise((resolve, reject) => {
           this.eventBus.once(Event.READY, () => {
             setTimeout(() => resolve(this), 0);
           });
-          // TODO - we can return the rejection here, like it's already doing, which will
-          // mean users have to surround this function with a try-catch or `then`
-          // and do error handling. Or we can just return the resolve here. Will
-          // discuss in PR.
           this.eventBus.once(Event.FAILED, reject);
         });
       }

--- a/src/client.ts
+++ b/src/client.ts
@@ -255,7 +255,7 @@ export default class Client {
           this.eventBus.once(Event.READY, () => {
             setTimeout(() => resolve(this), 0);
           });
-          // TODO - we can return the rejection here, live it's already doing, which will
+          // TODO - we can return the rejection here, like it's already doing, which will
           // mean users have to surround this function with a try-catch or `then`
           // and do error handling. Or we can just return the resolve here. Will
           // discuss in PR.

--- a/src/client.ts
+++ b/src/client.ts
@@ -236,6 +236,7 @@ export default class Client {
       console.error('Error while authenticating, err: ', error);
       warnAuthFailedSrvDefaults(this.log);
       warnFailedInitAuthError(this.log);
+      this.eventBus.emit(Event.FAILED);
     }
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -246,7 +246,10 @@ export default class Client {
         this.waitForInitializePromise = Promise.resolve(this);
         infoSDKInitOK(this.log);
       } else if (!this.initialized && this.failure) {
-        this.waitForInitializePromise = Promise.reject(this);
+        // We unblock the call even if initialization has failed. We've
+        // already warned the user that initialization has failed with the reason and that
+        // defaults will be served
+        this.waitForInitializePromise = Promise.resolve(this);
       } else {
         this.waitForInitializePromise = new Promise((resolve, reject) => {
           this.eventBus.once(Event.READY, () => {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "1.3.1";
+export const VERSION = '1.3.2';


### PR DESCRIPTION
# What
If authentication failed, the `Event.FAILED` event was not emitted and so the promise rejection was never handled by `waitForIntialization` , causing applications to exit with code 0 if the main script function is async

# Testing
Happy path: awaitForInitialziation still waits
Sad path: Used local proxy which returns a `404` error. The promise rejection gets passed to the caller.

# Note for reviewers
I've left a TODO comment over my change to get feedback on the approach we should take. Currently, this change means that the promise rejection will now be returned to the user, and it's up to them to handle it. But we could also just return the resolve promised, and allow the SDK to serve defaults. I think option A is better to give users more control.