### PR TITLE
fix: add type as deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
+        "@types/lru-cache": "^7.10.10",
         "axios": "^0.22.0",
         "axios-retry": "^3.2.0",
         "jwt-decode": "^3.1.2",
@@ -28,7 +29,6 @@
         "@openapitools/openapi-generator-cli": "^2.4.12",
         "@types/jest": "~26.0.23",
         "@types/keyv": "^3.1.3",
-        "@types/lru-cache": "^5.1.1",
         "@types/node": "^14.17.11",
         "@typescript-eslint/eslint-plugin": "~4.28.2",
         "@typescript-eslint/parser": "~4.28.2",
@@ -1771,9 +1771,13 @@
       }
     },
     "node_modules/@types/lru-cache": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT"
+      "version": "7.10.10",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-7.10.10.tgz",
+      "integrity": "sha512-nEpVRPWW9EBmx2SCfNn3ClYxPL7IktPX12HhIoSc/H5mMjdeW3+YsXIpseLQ2xF35+OcpwKQbEUw5VtqE4PDNA==",
+      "deprecated": "This is a stub types definition. lru-cache provides its own type definitions, so you do not need this installed.",
+      "dependencies": {
+        "lru-cache": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "14.17.11",
@@ -8208,8 +8212,12 @@
       }
     },
     "@types/lru-cache": {
-      "version": "5.1.1",
-      "dev": true
+      "version": "7.10.10",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-7.10.10.tgz",
+      "integrity": "sha512-nEpVRPWW9EBmx2SCfNn3ClYxPL7IktPX12HhIoSc/H5mMjdeW3+YsXIpseLQ2xF35+OcpwKQbEUw5VtqE4PDNA==",
+      "requires": {
+        "lru-cache": "*"
+      }
     },
     "@types/node": {
       "version": "14.17.11",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@openapitools/openapi-generator-cli": "^2.4.12",
     "@types/jest": "~26.0.23",
     "@types/keyv": "^3.1.3",
-    "@types/lru-cache": "^5.1.1",
     "@types/node": "^14.17.11",
     "@typescript-eslint/eslint-plugin": "~4.28.2",
     "@typescript-eslint/parser": "~4.28.2",
@@ -61,6 +60,7 @@
     "url": "https://github.com/harness/ff-nodejs-server-sdk"
   },
   "dependencies": {
+    "@types/lru-cache": "^7.10.10",
     "axios": "^0.22.0",
     "axios-retry": "^3.2.0",
     "jwt-decode": "^3.1.2",
@@ -84,5 +84,11 @@
   ],
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "bundleDependencies": [
+    "axios",
+    "eventsource",
+    "keyv",
+    "keyv-file"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -84,11 +84,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "bundleDependencies": [
-    "axios",
-    "eventsource",
-    "keyv",
-    "keyv-file"
-  ]
+  }
 }


### PR DESCRIPTION
![image](https://github.com/harness/ff-nodejs-server-sdk/assets/18364699/14cece70-f5dd-444c-ac63-c8914f128cf7)

Because `lru-cache` is referenced in `ff-nodejs-server-sdk` definition file and "@types/lru-cache" is not deps

`tsc` will fail without setting `skipLibChecks` to true on the user side

or installing both `@types/lru-cache` and `lru-cache` on the user side