### PR TITLE
fix: remove lru cache type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/lru-cache": "^7.10.10",
         "axios": "^0.22.0",
         "axios-retry": "^3.2.0",
         "jwt-decode": "^3.1.2",
@@ -1768,15 +1767,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/lru-cache": {
-      "version": "7.10.10",
-      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-7.10.10.tgz",
-      "integrity": "sha512-nEpVRPWW9EBmx2SCfNn3ClYxPL7IktPX12HhIoSc/H5mMjdeW3+YsXIpseLQ2xF35+OcpwKQbEUw5VtqE4PDNA==",
-      "deprecated": "This is a stub types definition. lru-cache provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "lru-cache": "*"
       }
     },
     "node_modules/@types/node": {
@@ -8209,14 +8199,6 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/lru-cache": {
-      "version": "7.10.10",
-      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-7.10.10.tgz",
-      "integrity": "sha512-nEpVRPWW9EBmx2SCfNn3ClYxPL7IktPX12HhIoSc/H5mMjdeW3+YsXIpseLQ2xF35+OcpwKQbEUw5VtqE4PDNA==",
-      "requires": {
-        "lru-cache": "*"
       }
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "url": "https://github.com/harness/ff-nodejs-server-sdk"
   },
   "dependencies": {
-    "@types/lru-cache": "^7.10.10",
     "axios": "^0.22.0",
     "axios-retry": "^3.2.0",
     "jwt-decode": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -85,5 +85,11 @@
   ],
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "bundleDependencies": [
+    "axios",
+    "eventsource",
+    "keyv",
+    "keyv-file"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,12 @@
     "murmurhash": "^2.0.0",
     "tslib": "~2.3.0"
   },
+  "bundledDependencies": [
+    "axios",
+    "eventsource",
+    "keyv",
+    "keyv-file"
+  ],
   "volta": {
     "node": "12.22.5"
   },

--- a/package.json
+++ b/package.json
@@ -84,11 +84,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "bundleDependencies": [
-    "axios",
-    "eventsource",
-    "keyv",
-    "keyv-file"
-  ]
+  }
 }


### PR DESCRIPTION
Follow up on https://github.com/harness/ff-nodejs-server-sdk/pull/84

The issue still happening, after further inspection of the @types it installed, the type is completely empty

<img width="967" alt="image" src="https://github.com/harness/ff-nodejs-server-sdk/assets/18364699/4421a46a-62b8-468e-997d-f090f0e18996">

After going to the npm page, the package is deprecated, lru-cache has moved to ts.
https://www.npmjs.com/package/@types/lru-cache

So by removing the @types it will work as expected
