### PR TITLE
FFM-9574 Upgrade `lru-cache` to version 7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "jwt-decode": "^3.1.2",
         "keyv": "^4.0.3",
         "keyv-file": "^0.2.0",
-        "lru-cache": "^6.0.0",
+        "lru-cache": "^7.0.0",
         "murmurhash": "^2.0.0",
         "tslib": "~2.3.0"
       },
@@ -5646,13 +5646,11 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -6366,6 +6364,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "dev": true,
@@ -7052,7 +7062,9 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -10777,10 +10789,9 @@
       }
     },
     "lru-cache": {
-      "version": "6.0.0",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
     },
     "make-dir": {
       "version": "3.1.0",
@@ -11201,6 +11212,17 @@
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
       }
     },
     "shebang-command": {
@@ -11638,7 +11660,10 @@
       "dev": true
     },
     "yallist": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yargs": {
       "version": "16.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.3.3",
+  "version": "1.3.4-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-nodejs-server-sdk",
-      "version": "1.3.3",
+      "version": "1.3.4-rc.1",
       "bundleDependencies": [
         "axios",
         "eventsource",
@@ -15,7 +15,6 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/lru-cache": "^7.10.10",
         "axios": "^0.22.0",
         "axios-retry": "^3.2.0",
         "jwt-decode": "^3.1.2",
@@ -1768,15 +1767,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/lru-cache": {
-      "version": "7.10.10",
-      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-7.10.10.tgz",
-      "integrity": "sha512-nEpVRPWW9EBmx2SCfNn3ClYxPL7IktPX12HhIoSc/H5mMjdeW3+YsXIpseLQ2xF35+OcpwKQbEUw5VtqE4PDNA==",
-      "deprecated": "This is a stub types definition. lru-cache provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "lru-cache": "*"
       }
     },
     "node_modules/@types/node": {
@@ -8209,14 +8199,6 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/lru-cache": {
-      "version": "7.10.10",
-      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-7.10.10.tgz",
-      "integrity": "sha512-nEpVRPWW9EBmx2SCfNn3ClYxPL7IktPX12HhIoSc/H5mMjdeW3+YsXIpseLQ2xF35+OcpwKQbEUw5VtqE4PDNA==",
-      "requires": {
-        "lru-cache": "*"
       }
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.3.3",
+  "version": "1.3.4-rc.1",
   "description": "Feature flags SDK for NodeJS environments",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",
@@ -61,7 +61,6 @@
     "url": "https://github.com/harness/ff-nodejs-server-sdk"
   },
   "dependencies": {
-    "@types/lru-cache": "^7.10.10",
     "axios": "^0.22.0",
     "axios-retry": "^3.2.0",
     "jwt-decode": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "jwt-decode": "^3.1.2",
     "keyv": "^4.0.3",
     "keyv-file": "^0.2.0",
-    "lru-cache": "^6.0.0",
+    "lru-cache": "^7.0.0",
     "murmurhash": "^2.0.0",
     "tslib": "~2.3.0"
   },

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -11,11 +11,13 @@ export class SimpleCache implements KeyValueStore {
     return this.cache[key];
   }
 
-  del(key: string): void {
+  delete(key: string): void {
     delete this.cache[key];
   }
 
-  keys(): string[] {
-    return Object.keys(this.cache);
+  *keys(): Generator<string, void, void> {
+    for (const key of Object.keys(this.cache)) {
+      yield key;
+    }
   }
 }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -45,7 +45,7 @@ export class StorageRepository implements Repository {
     const flagKey = this.formatFlagKey(identifier);
     if (this.store) {
       await this.store.set(flagKey, fc);
-      this.cache.del(flagKey);
+      this.cache.delete(flagKey);
     } else {
       this.cache.set(flagKey, fc);
     }
@@ -61,7 +61,7 @@ export class StorageRepository implements Repository {
     const segmentKey = this.formatSegmentKey(identifier);
     if (this.store) {
       await this.store.set(segmentKey, segment);
-      this.cache.del(segmentKey);
+      this.cache.delete(segmentKey);
     } else {
       this.cache.set(segmentKey, segment);
     }
@@ -75,7 +75,7 @@ export class StorageRepository implements Repository {
     if (this.store) {
       await this.store.del(flagKey);
     }
-    this.cache.del(flagKey);
+    this.cache.delete(flagKey);
     if (this.eventBus) {
       this.eventBus.emit(RepositoryEvent.FLAG_DELETED, identifier);
     }
@@ -86,7 +86,7 @@ export class StorageRepository implements Repository {
     if (this.store) {
       await this.store.del(segmentKey);
     }
-    this.cache.del(segmentKey);
+    this.cache.delete(segmentKey);
     if (this.eventBus) {
       this.eventBus.emit(RepositoryEvent.SEGMENT_DELETED, identifier);
     }
@@ -172,4 +172,6 @@ export class StorageRepository implements Repository {
   private formatSegmentKey(key: string): string {
     return `segments/${key}`;
   }
+
+
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -25,7 +25,11 @@ export class FileStore implements AsyncKeyValueStore {
     return this.keyv.delete(key);
   }
 
-  keys(): Promise<string[]> {
-    return Promise.resolve(this.keyvFile.keys());
+  keys(): Promise<Generator<string, void, void>> {
+    return Promise.resolve((function* (keys: string[]) {
+      for (const key of keys) {
+        yield key;
+      }
+    })(this.keyvFile.keys()));
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,15 +65,15 @@ export interface Query {
 export interface KeyValueStore {
   set(key: string, value: unknown): void;
   get(key: string): unknown;
-  del(key: string): void;
-  keys(): string[];
+  delete(key: string): void;
+  keys(): Generator<string, void, void>;
 }
 
 export interface AsyncKeyValueStore {
   set(key: string, value: unknown): Promise<true>;
   get<T>(key: string): Promise<T>;
   del(key: string): Promise<boolean>;
-  keys(): Promise<string[]>;
+  keys(): Promise<Generator<string, void, void>>;
 }
 
 export interface Target {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.3.3';
+export const VERSION = "1.3.4-rc.1";


### PR DESCRIPTION
# What
Upgrades `lru-cache` library to 7.0.0 

# Why
We export the `lru-cache` and a user could not `tsc` their project with our SDK installed. This is a valid issue, because version 6 of the library did not come with type defentions, and we were only providing the types as dev deps. 

We tried providing them as dependencies, but there was a mismatch bettwen the type defenition version and the library version. 

This version includes its own types, and comes with a big performance upgrade, but it required a minor refactor of `keys` and `del` 

# Testing
Manual - streaming, polling. Will carry out more extensive testing like deleting/updating flags and target groups etc.

