### PR TITLE
[FFM-9621] - Avoid sending empty metric payloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-nodejs-server-sdk",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "bundleDependencies": [
         "axios",
         "eventsource",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-nodejs-server-sdk",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "bundleDependencies": [
         "axios",
         "eventsource",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Feature flags SDK for NodeJS environments",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Feature flags SDK for NodeJS environments",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -189,7 +189,7 @@ export const MetricsProcessor = (
 
     const metrics: Metrics = _summarize();
 
-    if (metrics && metrics.metricsData.length + metrics.targetData.length > 0) {
+    if (metrics && metrics.metricsData.length && metrics.targetData.length) {
       log.debug('Start sending metrics data');
       api
         .postMetrics(environment, cluster, metrics)

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -188,7 +188,8 @@ export const MetricsProcessor = (
     }
 
     const metrics: Metrics = _summarize();
-    if (metrics) {
+
+    if (metrics && metrics.metricsData.length + metrics.targetData.length > 0) {
       log.debug('Start sending metrics data');
       api
         .postMetrics(environment, cluster, metrics)

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "1.3.4";
+export const VERSION = "1.3.5";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.3.3';
+export const VERSION = '1.3.4';


### PR DESCRIPTION
[FFM-9621] - Avoid sending empty metric payloads

What
Adds a check to make sure metrics data is not empty before sending it.

Why
We're seeing empty metrics payloads arriving at the BE we should avoid wasting network bandwidth.

Testing
Manual

[FFM-9621]: https://harness.atlassian.net/browse/FFM-9621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ