### PR TITLE
FFM-9761 Stringify Auth Error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-nodejs-server-sdk",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "bundleDependencies": [
         "axios",
         "eventsource",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Feature flags SDK for NodeJS environments",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/src/client.ts
+++ b/src/client.ts
@@ -233,7 +233,7 @@ export default class Client {
       this.cluster = decoded.clusterIdentifier || '1';
     } catch (error) {
       this.failure = true;
-      console.error('Error while authenticating, err: ', error);
+      console.error('Error while authenticating, err: ' + JSON.stringify(error));
       warnAuthFailedSrvDefaults(this.log);
       warnFailedInitAuthError(this.log);
       this.eventBus.emit(Event.FAILED, error);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "1.3.5";
+export const VERSION = "1.3.6";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "1.3.6";
+export const VERSION = '1.3.6';


### PR DESCRIPTION
# What
For auth errors, stringify the error so that it appears on the same line. 

# Why
In cloud logging, the `error` object appears on multiple lines. 

# Testing
Will release an RC for the internal team to check