### PR TITLE
FFM-9778 Update some log statements from console to the SDK's logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-nodejs-server-sdk",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "bundleDependencies": [
         "axios",
         "eventsource",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Feature flags SDK for NodeJS environments",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/src/client.ts
+++ b/src/client.ts
@@ -224,7 +224,7 @@ export default class Client {
 
       if (!decoded.environment) {
         this.failure = true;
-        console.error(
+        this.log.error(
           'Error while authenticating, err:  the JWT token has missing claim "environmentUUID" ',
         );
       }
@@ -233,7 +233,7 @@ export default class Client {
       this.cluster = decoded.clusterIdentifier || '1';
     } catch (error) {
       this.failure = true;
-      console.error('Error while authenticating, err: ', error);
+      this.log.error('Error while authenticating, err: ', error);
       warnAuthFailedSrvDefaults(this.log);
       warnFailedInitAuthError(this.log);
       this.eventBus.emit(Event.FAILED, error);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "1.3.5";
+export const VERSION = '1.3.6';


### PR DESCRIPTION
# What
Two log statements were using `console` instead of the `Logger` interface, this PR updates those references. 

# Why
So any customer loggers that are provides work across all log statements.