### PR TITLE
[FFM-10041] - Fall back to identifier if bucketBy attr is not found

### DIFF
--- a/examples/getting_started/package-lock.json
+++ b/examples/getting_started/package-lock.json
@@ -13,7 +13,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-nodejs-server-sdk",
-      "version": "1.3.8",
+      "version": "1.4.0",
       "bundleDependencies": [
         "axios",
         "eventsource",

--- a/examples/getting_started/package-lock.json
+++ b/examples/getting_started/package-lock.json
@@ -13,7 +13,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-nodejs-server-sdk",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "bundleDependencies": [
         "axios",
         "eventsource",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.3.8",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-nodejs-server-sdk",
-      "version": "1.3.8",
+      "version": "1.4.0",
       "bundleDependencies": [
         "axios",
         "eventsource",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-nodejs-server-sdk",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "bundleDependencies": [
         "axios",
         "eventsource",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.3.8",
+  "version": "1.4.0",
   "description": "Feature flags SDK for NodeJS environments",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Feature flags SDK for NodeJS environments",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/src/__tests__/evaluator.test.ts
+++ b/src/__tests__/evaluator.test.ts
@@ -1,0 +1,80 @@
+import { Evaluator } from '../evaluator';
+import { Logger } from '../log';
+
+describe('Evaluator', () => {
+  it('should return identifier if bucketby attribute does not exist', async () => {
+    const logger: Logger = {
+      trace: jest.fn(),
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+
+    const mockQuery = {
+      getFlag: jest.fn(),
+      getSegment: jest.fn(),
+      findFlagsBySegment: jest.fn(),
+    };
+
+    const featureConfig = {
+      feature: 'flag',
+      kind: 'string',
+      state: 'on',
+      variationToTargetMap: [],
+      variations: [
+        { identifier: 'variation1', value: 'default_on' },
+        { identifier: 'variation2', value: 'wanted_value' },
+        { identifier: 'variation3', value: 'default_off' },
+      ],
+      defaultServe: {
+        distribution: null,
+        variation: 'default_on',
+      },
+      offVariation: 'variation3',
+      rules: [
+        {
+          ruleId: 'rule1',
+          clauses: [
+            {
+              op: 'equal',
+              attribute: 'identifier',
+              values: ['test'],
+            },
+          ],
+          serve: {
+            distribution: {
+              bucketBy: 'i_do_not_exist',
+              variations: [
+                { variation: 'variation1', weight: 56 },
+                { variation: 'variation2', weight: 1 }, // bucket 57
+                { variation: 'variation3', weight: 43 },
+              ],
+            },
+          },
+        },
+      ],
+    };
+
+    mockQuery.getFlag.mockReturnValue(featureConfig);
+
+    const evaluator = new Evaluator(mockQuery, logger);
+
+    const target = {
+      identifier: 'test', // Test will fall back to bucketing on this (bucket 57)
+      name: 'test name',
+      attributes: {
+        location: 'emea',
+      },
+    };
+
+    const actualVariation = await evaluator.stringVariation(
+      'flag',
+      target,
+      'fallback_value',
+      null,
+    );
+
+    expect(actualVariation).toEqual('wanted_value');
+  });
+});

--- a/src/__tests__/evaluator.test.ts
+++ b/src/__tests__/evaluator.test.ts
@@ -2,7 +2,7 @@ import { Evaluator } from '../evaluator';
 import { Logger } from '../log';
 
 describe('Evaluator', () => {
-  it('should return identifier if bucketby attribute does not exist', async () => {
+  it('should fallback to identifier if bucketby attribute does not exist', async () => {
     const logger: Logger = {
       trace: jest.fn(),
       debug: jest.fn(),
@@ -11,13 +11,13 @@ describe('Evaluator', () => {
       error: jest.fn(),
     };
 
-    const mockQuery = {
+    const mock_query = {
       getFlag: jest.fn(),
       getSegment: jest.fn(),
       findFlagsBySegment: jest.fn(),
     };
 
-    const featureConfig = {
+    const feature_config = {
       feature: 'flag',
       kind: 'string',
       state: 'on',
@@ -56,9 +56,9 @@ describe('Evaluator', () => {
       ],
     };
 
-    mockQuery.getFlag.mockReturnValue(featureConfig);
+    mock_query.getFlag.mockReturnValue(feature_config);
 
-    const evaluator = new Evaluator(mockQuery, logger);
+    const evaluator = new Evaluator(mock_query, logger);
 
     const target = {
       identifier: 'test', // Test will fall back to bucketing on this (bucket 57)
@@ -68,13 +68,13 @@ describe('Evaluator', () => {
       },
     };
 
-    const actualVariation = await evaluator.stringVariation(
+    const actual_variation = await evaluator.stringVariation(
       'flag',
       target,
       'fallback_value',
       null,
     );
 
-    expect(actualVariation).toEqual('wanted_value');
+    expect(actual_variation).toEqual('wanted_value');
   });
 });

--- a/src/__tests__/sdk_codes.test.ts
+++ b/src/__tests__/sdk_codes.test.ts
@@ -44,6 +44,7 @@ describe('SDK Codes', () => {
       'warnDefaultVariationServed',
       ['flag', { name: 'dummy', identifier: 'dummy' }, 'default value', logger],
     ],
+    ['warnBucketByAttributeNotFound', ['dummy1', 'dummy2', logger]],
   ])('it should not throw when %s is called', (fn, args) => {
     expect(() => sdkCodes[fn](...args)).not.toThrow();
   });

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -58,8 +58,8 @@ export class Evaluator {
   }
 
   private getNormalizedNumberWithNormalizer(
-    property: Type,
     bucketBy: string,
+    property: Type,
     normalizer: number,
   ): number {
     const value = [bucketBy, property].join(':');
@@ -67,10 +67,10 @@ export class Evaluator {
     return (hash % normalizer) + 1;
   }
 
-  private getNormalizedNumber(property: Type, bucketBy: string): number {
+  private getNormalizedNumber(bucketBy: string, property: Type): number {
     return this.getNormalizedNumberWithNormalizer(
-      property,
       bucketBy,
+      property,
       ONE_HUNDRED,
     );
   }
@@ -80,23 +80,19 @@ export class Evaluator {
     bucketBy: string,
     percentage: number,
   ): boolean {
-    let property = this.getAttrValue(target, bucketBy);
+    let bb = bucketBy;
+    let property = this.getAttrValue(target, bb);
     if (!property) {
-      const oldBucketBy = bucketBy;
-      bucketBy = 'identifier';
-      property = this.getAttrValue(target, bucketBy);
-      
+      bb = 'identifier';
+      property = this.getAttrValue(target, bb);
+
       if (!property) {
         return false;
       }
-      
-      warnBucketByAttributeNotFound(
-        old_bucketBy,
-        property?.toString(),
-        this.log,
-      );
+
+      warnBucketByAttributeNotFound(bb, property?.toString(), this.log);
     }
-    const bucketId = this.getNormalizedNumber(property, bucketBy);
+    const bucketId = this.getNormalizedNumber(bb, property);
     return percentage > 0 && bucketId <= percentage;
   }
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -85,9 +85,11 @@ export class Evaluator {
       const oldBucketBy = bucketBy;
       bucketBy = 'identifier';
       property = this.getAttrValue(target, bucketBy);
+      
       if (!property) {
         return false;
       }
+      
       warnBucketByAttributeNotFound(
         old_bucketBy,
         property?.toString(),

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -82,7 +82,7 @@ export class Evaluator {
   ): boolean {
     let property = this.getAttrValue(target, bucketBy);
     if (!property) {
-      const old_bucketBy = bucketBy;
+      const oldBucketBy = bucketBy;
       bucketBy = 'identifier';
       property = this.getAttrValue(target, bucketBy);
       if (!property) {

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -90,7 +90,7 @@ export class Evaluator {
         return false;
       }
 
-      warnBucketByAttributeNotFound(bb, property?.toString(), this.log);
+      warnBucketByAttributeNotFound(bucketBy, property?.toString(), this.log);
     }
     const bucketId = this.getNormalizedNumber(bb, property);
     return percentage > 0 && bucketId <= percentage;

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -26,6 +26,7 @@ const sdkCodes: Record<number, string> = {
   // SDK_EVAL_6xxx -
   6000: 'Evaluation successful: ',
   6001: 'Evaluation Failed, returning default variation: ',
+  6002: "BucketBy attribute not found in target attributes, falling back to 'identifier':",
   // SDK_METRICS_7xxx
   7000: 'Metrics thread started with request interval:',
   7001: 'Metrics stopped',
@@ -171,5 +172,15 @@ export function warnDefaultVariationServed(
         target,
       )}`,
     ),
+  );
+}
+
+export function warnBucketByAttributeNotFound(
+  bucketBy: string,
+  usingValue: string,
+  logger: Logger,
+): void {
+  logger.warn(
+    getSdkErrMsg(6002, `missing=${bucketBy}, using value=${usingValue}`),
   );
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.3.8';
+export const VERSION = '1.4.0';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.3.7';
+export const VERSION = '1.3.8';


### PR DESCRIPTION
[FFM-10041] - Fall back to identifier if bucketBy attribute is not found

**What**
Update BucketBy logic to fall back to the target identifier if given BucketBy attribute is not found.
Adds new unit test to test fallback logic works.

**Why**
Keep the SDK consistent with the behaviour of the other server SDKs.

**Testing**
Testgrid + new unit test

[FFM-10041]: https://harness.atlassian.net/browse/FFM-10041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ