### PR TITLE
Fix metric not sending when metric target is empty

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -189,7 +189,7 @@ export const MetricsProcessor = (
 
     const metrics: Metrics = _summarize();
 
-    if (metrics && metrics.metricsData.length && metrics.targetData.length) {
+    if (metrics && (metrics.metricsData.length || metrics.targetData.length)) {
       log.debug('Start sending metrics data');
       api
         .postMetrics(environment, cluster, metrics)


### PR DESCRIPTION
An issue arises if all your feature flag query calls do not have target, this will result in empty targetData, but with data in metricsData.

This fix metric processor so that it would send metric, if either metricsData or targetData has something in it.

This is raised in a zendesk support ticket 55786.
