### PR TITLE
FFM-10409 Mark targets as optional for variation methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-nodejs-server-sdk",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Feature flags SDK for NodeJS environments",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/src/client.ts
+++ b/src/client.ts
@@ -350,7 +350,7 @@ export default class Client {
 
   boolVariation(
     identifier: string,
-    target: Target,
+    target?: Target,
     defaultValue = false,
   ): Promise<boolean> {
     if (!this.initialized) {
@@ -378,7 +378,7 @@ export default class Client {
 
   stringVariation(
     identifier: string,
-    target: Target,
+    target?: Target,
     defaultValue = '',
   ): Promise<string> {
     if (!this.initialized) {
@@ -406,7 +406,7 @@ export default class Client {
 
   numberVariation(
     identifier: string,
-    target: Target,
+    target?: Target,
     defaultValue = 0,
   ): Promise<number> {
     if (!this.initialized) {
@@ -434,7 +434,7 @@ export default class Client {
 
   jsonVariation(
     identifier: string,
-    target: Target,
+    target?: Target,
     defaultValue = {},
   ): Promise<Record<string, unknown>> {
     if (!this.initialized) {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.5.0';
+export const VERSION = '1.6.0';


### PR DESCRIPTION
# What
We allow targets to to undefined when calling variation methods, but if `"strictNullChecks": true` is enabled in a Typescript project, then passing an undefined target will result in a compilation fail.
This marks the `target` as explicitly optional for all variation methods.

# Testing
Manual:
1. with project that enabled `strictNullChecks` and passed undefined targets and real targets with targeting rules enabled on each flag type.
2. with project with no `strictNullChecks` for undefined and real targets with targeting rules enabled on each flag type.
3. Metrics post for each of the above scenarios correctly.
