### PR TITLE
[FFM-9291] - Fixed first prerequisite only being processed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-nodejs-server-sdk",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Feature flags SDK for NodeJS environments",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -356,7 +356,9 @@ export class Evaluator {
         if (!pqs.variations.includes(variation.identifier)) {
           return false;
         } else {
-          return await this.checkPreRequisite(preReqFeatureConfig, target);
+          if (!(await this.checkPreRequisite(preReqFeatureConfig, target))) {
+            return false;
+          }
         }
       }
     }

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -1,9 +1,10 @@
 import { Logger } from './log';
 import { Target } from './types';
+import { VERSION } from './version';
 
 const sdkCodes: Record<number, string> = {
   // SDK_INIT_1xxx
-  1000: 'The SDK has successfully initialized',
+  1000: 'The SDK has successfully initialized, version ' + VERSION,
   1001: 'The SDK has failed to initialize due to an authentication error - defaults will be served',
   1002: 'The SDK has failed to initialize due to a missing or empty API key - defaults will be served',
   // SDK_AUTH_2xxx

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.6.1';
+export const VERSION = '1.6.2';


### PR DESCRIPTION
**What**
Fix prereq loop not to abort too soon, allowing subsequent prereqs to be processed

**Why**
The old logic aborts immediately after the first iteration of the loop. This causes a lot of test grid failures.

**Testing**
The following testgrid test cases are now working:

```
Custom_SDK_:_Type=BoolWith2JSON;State=Enabled;On=True;Off=False;Prereq=AlwaysOn;AlwaysOnToo;Return_False 
Custom_SDK_:_Type=BoolWith2Bool;State=Enabled;On=True;Off=False;Prereq=AlwaysOn;AlwaysOff;Return_False 
Custom_SDK_:_Type=BoolWith2Bool;State=Enabled;On=True;Off=False;Prereq=AlwaysOn;AlwaysOnToo;Return_False 
Custom_SDK_:_Type=BoolWithBoolJSON;State=Enabled;On=True;Off=False;Prereq=AlwaysOn;AlwaysOnToo;Return_False 
Custom_SDK_:_Type=JSONWith2Bool;State=Enabled;On=Com;Off=Val;Prereq=AlwaysOn;AlwaysOff;Return_Val 
Custom_SDK_:_Type=JSONWith2Bool;State=Enabled;On=Com;Off=Val;Prereq=AlwaysOn;AlwaysOnToo;Return_Val 
Custom_SDK_:_Type=JSONWith2JSON;State=Enabled;On=Com;Off=Val;Prereq=AlwaysOn;AlwaysOnToo;Return_Val 
Custom_SDK_:_Type=NumWith2Bool;State=Enabled;On=2;Off=0.11;Prereq=AlwaysOn;AlwaysOff;Return_0.11 
Custom_SDK_:_Type=NumWith2Bool;State=Enabled;On=2;Off=0.11;Prereq=AlwaysOn;AlwaysOnToo;Return_0.11 
Custom_SDK_:_Type=NumWith2JSON;State=Enabled;On=2;Off=0.11;Prereq=AlwaysOn;AlwaysOnToo;Return_0.11 
Custom_SDK_:_Type=NumWithNumBool;State=Enabled;On=2;Off=0.11;Prereq=AlwaysOn;AlwaysOff;Return_0.11 
Custom_SDK_:_Type=NumWithNumBool;State=Enabled;On=2;Off=0.11;Prereq=AlwaysOn;AlwaysOnToo;Return_0.11 
Custom_SDK_:_Type=NumWithNumJSON;State=Enabled;On=2;Off=0.11;Prereq=AlwaysOn;AlwaysOnToo;Return_0.11 
Custom_SDK_:_Type=NumWithNumStr;State=Enabled;On=2;Off=0.11;Prereq=AlwaysOn;AlwaysOff;Return_0.11

```