### PR TITLE
[FFM-7017] - Add Harness-SDK-Info/Harness-AccountID/Harness-EnvironmentID headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-nodejs-server-sdk",
-      "version": "1.6.2",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "Feature flags SDK for NodeJS environments",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/src/client.ts
+++ b/src/client.ts
@@ -340,9 +340,10 @@ export default class Client {
         this.cluster,
         this.eventBus,
         this.repository,
+        this.configuration.baseOptions.headers,
       );
 
-      this.streamProcessor.start(this.configuration.baseOptions.headers);
+      this.streamProcessor.start();
     }
 
     if (this.options.enableAnalytics) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -44,6 +44,8 @@ export enum Event {
   CHANGED = 'changed',
 }
 
+export const SDK_INFO = `NodeJS ${VERSION} Server`;
+
 export default class Client {
   private evaluator: Evaluator;
   private repository: Repository;
@@ -91,6 +93,7 @@ export default class Client {
       baseOptions: {
         headers: {
           'User-Agent': `NodeJsSDK/${VERSION}`,
+          'Harness-SDK-Info': SDK_INFO,
         },
       },
     });
@@ -229,6 +232,16 @@ export default class Client {
         );
       }
 
+      if (decoded.accountID) {
+        this.configuration.baseOptions.headers['Harness-AccountID'] =
+          decoded.accountID;
+      }
+
+      if (decoded.environmentIdentifier) {
+        this.configuration.baseOptions.headers['Harness-EnvironmentID'] =
+          decoded.environmentIdentifier;
+      }
+
       this.environment = decoded.environment;
       this.cluster = decoded.clusterIdentifier || '1';
     } catch (error) {
@@ -329,7 +342,7 @@ export default class Client {
         this.repository,
       );
 
-      this.streamProcessor.start();
+      this.streamProcessor.start(this.configuration.baseOptions.headers);
     }
 
     if (this.options.enableAnalytics) {

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -33,6 +33,7 @@ export class StreamProcessor {
   private readonly api: ClientApi;
   private readonly repository: Repository;
   private readonly retryDelayMs: number;
+  private readonly headers: Record<string, string>;
 
   private options: Options;
   private request: ClientRequest;
@@ -50,6 +51,7 @@ export class StreamProcessor {
     cluster: string,
     eventBus: EventEmitter,
     repository: Repository,
+    headers: Record<string, string>,
   ) {
     this.api = api;
     this.apiKey = apiKey;
@@ -66,9 +68,10 @@ export class StreamProcessor {
     this.retryDelayMs = Math.floor(
       Math.random() * (maxDelay - minDelay) + minDelay,
     );
+    this.headers = headers;
   }
 
-  start(headers: Record<string, string>): void {
+  start(): void {
     this.log.info('Starting new StreamProcessor');
 
     const url = `${this.options.baseUrl}/stream?cluster=${this.cluster}`;
@@ -79,7 +82,7 @@ export class StreamProcessor {
         Accept: 'text/event-stream',
         Authorization: `Bearer ${this.jwtToken}`,
         'API-Key': this.apiKey,
-        ...headers,
+        ...this.headers,
       },
     };
 

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -14,8 +14,6 @@ import {
   warnStreamRetrying,
 } from './sdk_codes';
 
-import { SDK_INFO } from './client';
-
 type FetchFunction = (
   identifier: string,
   environment: string,

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -14,6 +14,8 @@ import {
   warnStreamRetrying,
 } from './sdk_codes';
 
+import { SDK_INFO } from './client';
+
 type FetchFunction = (
   identifier: string,
   environment: string,
@@ -68,7 +70,7 @@ export class StreamProcessor {
     );
   }
 
-  start(): void {
+  start(headers: Record<string, string>): void {
     this.log.info('Starting new StreamProcessor');
 
     const url = `${this.options.baseUrl}/stream?cluster=${this.cluster}`;
@@ -79,6 +81,7 @@ export class StreamProcessor {
         Accept: 'text/event-stream',
         Authorization: `Bearer ${this.jwtToken}`,
         'API-Key': this.apiKey,
+        ...headers,
       },
     };
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.6.2';
+export const VERSION = '1.7.0';


### PR DESCRIPTION
[FFM-7017] - Add Harness-SDK-Info/Harness-AccountID/Harness-EnvironmentID headers

**What**
Add meta data headers `Harness-SDK-Info`, `Harness-AccountID` and `Harness-EnvironmentID` to bring NodeJS in line with other server SDKs.

**Why**
Helps with backend load testing to identify problematic clients

**Testing**
Manual with Java SDK proxy

[FFM-7017]: https://harness.atlassian.net/browse/FFM-7017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ