### PR TITLE
[FFM-7017] - Add support for custom TLS CAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,15 +110,12 @@ If using a proxy or SMP instance that does not use a widely publicised pre-bundl
 This option takes a path to a file that contains a bundle of certificates in PEM format. If this option is present, the HTTP client will ignore
 any pre-bundled certs so you need to include the entire certificate chain of your custom cert.
 
-
 ```
   const client = new Client(apiKey, {
     baseUrl: 'https://ffserver:8000/api/1.0',
     eventsUrl: 'https://ffserver:8001/api/1.0',
-    tlsTrustedCa:
-      'path_to_cert_chain.crt',
+    tlsTrustedCa: 'path_to_cert_chain.crt',
   });
-
 ```
 
 ## Additional Reading

--- a/README.md
+++ b/README.md
@@ -103,6 +103,24 @@ node example.js
 
 When you're finished you can exit the example by stopping the process using <kbd>control</kbd>-<kbd>c</kbd>.
 
+
+## Using custom TLS certificates
+
+If using a proxy or SMP instance that does not use a widely publicised pre-bundled CA you can provide your own CA using the `tlsTrustedCa` option.
+This option takes a path to a file that contains a bundle of certificates in PEM format. If this option is present, the HTTP client will ignore
+any pre-bundled certs so you need to include the entire certificate chain of your custom cert.
+
+
+```
+  const client = new Client(apiKey, {
+    baseUrl: 'https://ffserver:8000/api/1.0',
+    eventsUrl: 'https://ffserver:8001/api/1.0',
+    tlsTrustedCa:
+      'path_to_cert_chain.crt',
+  });
+
+```
+
 ## Additional Reading
 
 For further examples and config options, see the [Node.js SDK Reference](https://docs.harness.io/article/3v7fclfg59-node-js-sdk-reference) and the [test Node.js project](https://github.com/drone/ff-nodejs-server-sdk).

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 import jwt_decode from 'jwt-decode';
-import axios from 'axios';
+import axios, { AxiosInstance } from 'axios';
 import axiosRetry from 'axios-retry';
 import { Claims, Options, StreamEvent, Target } from './types';
 import { Configuration, ClientApi, FeatureConfig, Variation } from './openapi';
@@ -70,6 +70,8 @@ export default class Client {
   private streamReady = false;
   private metricReady = false;
   private closing = false;
+  private httpsClient: AxiosInstance;
+  private httpsCa: Buffer;
 
   constructor(sdkKey: string, options: Options = {}) {
     this.sdkKey = sdkKey;
@@ -108,10 +110,22 @@ export default class Client {
     this.evaluator = new Evaluator(this.repository, this.log);
 
     if (options.tlsTrustedCa) {
-      https.globalAgent.options.ca = fs.readFileSync(options.tlsTrustedCa);
+      this.httpsCa = fs.readFileSync(options.tlsTrustedCa);
+      this.httpsClient = axios.create({
+        httpsAgent: new https.Agent({
+          ca: this.httpsCa,
+        }),
+      });
+
+      this.api = new ClientApi(
+        this.configuration,
+        this.options.baseUrl,
+        this.httpsClient,
+      );
+    } else {
+      this.api = new ClientApi(this.configuration);
     }
 
-    this.api = new ClientApi(this.configuration);
     this.processEvents();
     this.run();
   }
@@ -348,6 +362,7 @@ export default class Client {
         this.eventBus,
         this.repository,
         this.configuration.baseOptions.headers,
+        this.httpsCa,
       );
 
       this.streamProcessor.start();
@@ -360,6 +375,8 @@ export default class Client {
         this.configuration,
         this.options,
         this.eventBus,
+        false,
+        this.httpsClient,
       );
       this.metricsProcessor.start();
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -28,6 +28,8 @@ import {
   warnFailedInitAuthError,
   warnMissingSDKKey,
 } from './sdk_codes';
+import https from 'https';
+import * as fs from 'fs';
 
 axios.defaults.timeout = 30000;
 axiosRetry(axios, { retries: 3, retryDelay: axiosRetry.exponentialDelay });
@@ -104,6 +106,11 @@ export default class Client {
       this.eventBus,
     );
     this.evaluator = new Evaluator(this.repository, this.log);
+
+    if (options.tlsTrustedCa) {
+      https.globalAgent.options.ca = fs.readFileSync(options.tlsTrustedCa);
+    }
+
     this.api = new ClientApi(this.configuration);
     this.processEvents();
     this.run();

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -87,7 +87,10 @@ export class MetricsProcessor implements MetricsProcessorInterface {
       'Starting MetricsProcessor with request interval: ',
       this.options.eventsSyncInterval,
     );
-    this.syncInterval = setInterval(() => this._send(), this.options.eventsSyncInterval);
+    this.syncInterval = setInterval(
+      () => this._send(),
+      this.options.eventsSyncInterval,
+    );
     this.eventBus.emit(MetricEvent.READY);
   }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -30,6 +30,7 @@ import {
   warnPostMetricsFailed,
 } from './sdk_codes';
 import { Logger } from './log';
+import { AxiosInstance } from 'axios';
 
 export enum MetricEvent {
   READY = 'metrics_ready',
@@ -66,13 +67,18 @@ export class MetricsProcessor implements MetricsProcessorInterface {
     private options: Options,
     private eventBus: events.EventEmitter,
     private closed: boolean = false,
+    private httpsClient: AxiosInstance,
   ) {
     const configuration = new Configuration({
       ...this.conf,
       basePath: options.eventsUrl,
     });
+    if (httpsClient) {
+      this.api = new MetricsApi(this.conf, options.eventsUrl, this.httpsClient);
+    } else {
+      this.api = new MetricsApi(configuration);
+    }
 
-    this.api = new MetricsApi(configuration);
     this.log = options.logger;
   }
 

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -176,8 +176,8 @@ export class StreamProcessor {
 
   private processData(data: any): void {
     const lines = data.toString().split(/\r?\n/);
-    if (lines[0].startsWith(":")) {
-      this.log.debug("SSE Heartbeat received")
+    if (lines[0].startsWith(':')) {
+      this.log.debug('SSE Heartbeat received');
       return;
     }
     lines.forEach((line) => this.processLine(line));

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -87,6 +87,7 @@ export class StreamProcessor {
         'API-Key': this.apiKey,
         ...this.headers,
       },
+      ca: undefined,
     };
 
     if (this.httpsCa) {

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -34,6 +34,7 @@ export class StreamProcessor {
   private readonly repository: Repository;
   private readonly retryDelayMs: number;
   private readonly headers: Record<string, string>;
+  private readonly httpsCa: Buffer;
 
   private options: Options;
   private request: ClientRequest;
@@ -52,6 +53,7 @@ export class StreamProcessor {
     eventBus: EventEmitter,
     repository: Repository,
     headers: Record<string, string>,
+    httpsCa: Buffer,
   ) {
     this.api = api;
     this.apiKey = apiKey;
@@ -69,6 +71,7 @@ export class StreamProcessor {
       Math.random() * (maxDelay - minDelay) + minDelay,
     );
     this.headers = headers;
+    this.httpsCa = httpsCa;
   }
 
   start(): void {
@@ -85,6 +88,10 @@ export class StreamProcessor {
         ...this.headers,
       },
     };
+
+    if (this.httpsCa) {
+      options.ca = this.httpsCa;
+    }
 
     const onConnected = () => {
       this.log.info(`SSE stream connected OK: ${url}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface Options {
   cache?: KeyValueStore;
   store?: AsyncKeyValueStore;
   logger?: Logger;
+  tlsTrustedCa?: string;
 }
 
 export interface Claims {


### PR DESCRIPTION
**What**
Adds a new option called `tlsTrustedCa` that takes a path to a file that contains a bundle of certificates in PEM format.

**Why**
Bring NodeJS into line with other SDKs by adding TLS support at the API level.

**Testing**
Tested with Java proxy (with TLS enabled) + testgrid