### PR TITLE
FFM-11022 Applies standard Metrics Enhancements

### DIFF
--- a/src/__tests__/sdk_codes.test.ts
+++ b/src/__tests__/sdk_codes.test.ts
@@ -22,6 +22,8 @@ describe('SDK Codes', () => {
     ['debugStreamEventReceived', [logger]],
     ['infoStreamStopped', [logger]],
     ['infoMetricsSuccess', [logger]],
+    ['infoTargetMetricsExceeded', [logger]],
+    ['infoEvaluationMetricsExceeded', [logger]],
     ['infoMetricsThreadExited', [logger]],
     [
       'debugEvalSuccess',

--- a/src/__tests__/sdk_codes.test.ts
+++ b/src/__tests__/sdk_codes.test.ts
@@ -22,8 +22,8 @@ describe('SDK Codes', () => {
     ['debugStreamEventReceived', [logger]],
     ['infoStreamStopped', [logger]],
     ['infoMetricsSuccess', [logger]],
-    ['infoTargetMetricsExceeded', [logger]],
-    ['infoEvaluationMetricsExceeded', [logger]],
+    ['warnTargetMetricsExceeded', [logger]],
+    ['warnEvaluationMetricsExceeded', [logger]],
     ['infoMetricsThreadExited', [logger]],
     [
       'debugEvalSuccess',

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -148,15 +148,15 @@ export class MetricsProcessor implements MetricsProcessorInterface {
           key: FEATURE_IDENTIFIER_ATTRIBUTE,
           value: event.featureConfig.feature,
         },
-        { key: FEATURE_NAME_ATTRIBUTE, value: event.featureConfig.feature },
         {
           key: VARIATION_IDENTIFIER_ATTRIBUTE,
           value: event.variation.identifier,
         },
+        { key: FEATURE_NAME_ATTRIBUTE, value: event.featureConfig.feature },
         { key: SDK_TYPE_ATTRIBUTE, value: SDK_TYPE },
         { key: SDK_LANGUAGE_ATTRIBUTE, value: SDK_LANGUAGE },
         { key: SDK_VERSION_ATTRIBUTE, value: VERSION },
-        { key: TARGET_ATTRIBUTE, value: event.target.identifier },
+        { key: TARGET_ATTRIBUTE, value: event?.target?.identifier ?? null },
       ];
 
       const md: MetricsData = {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -123,9 +123,10 @@ export class MetricsProcessor implements MetricsProcessorInterface {
       this.evaluationAnalytics.set(key, event);
     }
 
-    if (target && target.identifier) {
-      // If target has been seen or is anonymous then ignore it
-      if (this.seenTargets.has(target.identifier) || target.anonymous) {
+    if (target && !target.anonymous) {
+
+      // If target has been seen then ignore it
+      if (this.seenTargets.has(target.identifier)) {
         return;
       }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -223,10 +223,7 @@ export class MetricsProcessor implements MetricsProcessorInterface {
         );
       }
 
-      let targetName = target.identifier;
-      if (target.name) {
-        targetName = target.name;
-      }
+      const targetName = target.name || target.identifier;
 
       const td: TargetData = {
         identifier: target.identifier,

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -225,12 +225,11 @@ export class MetricsProcessor implements MetricsProcessorInterface {
 
       const targetName = target.name || target.identifier;
 
-      const td: TargetData = {
+      targetData.push({
         identifier: target.identifier,
         name: targetName,
         attributes: targetAttributes,
-      };
-      targetData.push(td);
+      });
     });
 
     return {
@@ -245,7 +244,7 @@ export class MetricsProcessor implements MetricsProcessorInterface {
       return;
     }
 
-    if (this.evaluationAnalytics.size === 0) {
+    if (!this.evaluationAnalytics.size) {
       this.log.debug('No metrics to send in this interval');
       return;
     }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -127,7 +127,7 @@ export class MetricsProcessor implements MetricsProcessorInterface {
     this.storeTargetAnalytic(target);
   }
 
-  private storeTargetAnalytic(target: Target) {
+  private storeTargetAnalytic(target: Target): void {
     if (this.targetAnalytics.size >= this.MAX_TARGET_ANALYTICS_SIZE) {
       if (!this.targetAnalyticsExceeded) {
         this.targetAnalyticsExceeded = true;

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -148,7 +148,7 @@ export class MetricsProcessor implements MetricsProcessorInterface {
     }
   }
 
-  private storeEvaluationAnalytic(event: AnalyticsEvent) {
+  private storeEvaluationAnalytic(event: AnalyticsEvent): void {
     if (this.evaluationAnalytics.size >= this.MAX_EVALUATION_ANALYTICS_SIZE) {
       if (!this.evaluationAnalyticsExceeded) {
         this.evaluationAnalyticsExceeded = true;

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -25,10 +25,10 @@ import {
 import { Options, Target } from './types';
 import { VERSION } from './version';
 import {
-  infoEvaluationMetricsExceeded,
+  warnEvaluationMetricsExceeded,
   infoMetricsSuccess,
   infoMetricsThreadExited,
-  infoTargetMetricsExceeded,
+  warnTargetMetricsExceeded,
   warnPostMetricsFailed,
 } from './sdk_codes';
 import { Logger } from './log';
@@ -131,7 +131,7 @@ export class MetricsProcessor implements MetricsProcessorInterface {
     if (this.targetAnalytics.size >= this.MAX_TARGET_ANALYTICS_SIZE) {
       if (!this.targetAnalyticsExceeded) {
         this.targetAnalyticsExceeded = true;
-        infoTargetMetricsExceeded(this.log);
+        warnTargetMetricsExceeded(this.log);
       }
 
       return;
@@ -152,7 +152,7 @@ export class MetricsProcessor implements MetricsProcessorInterface {
     if (this.evaluationAnalytics.size >= this.MAX_EVALUATION_ANALYTICS_SIZE) {
       if (!this.evaluationAnalyticsExceeded) {
         this.evaluationAnalyticsExceeded = true;
-        infoEvaluationMetricsExceeded(this.log);
+        warnEvaluationMetricsExceeded(this.log);
       }
 
       return;

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -33,6 +33,8 @@ const sdkCodes: Record<number, string> = {
   7001: 'Metrics stopped',
   7002: 'Posting metrics failed, reason:',
   7003: 'Metrics posted successfully',
+  7004: 'Target metrics exceeded max size, remaining targets for this analytics interval will not be sent',
+  7007: 'Evaluation metrics exceeded max size, remaining evaluations for this analytics interval will not be sent'
 };
 
 function getSDKCodeMessage(key: number): string {
@@ -105,6 +107,14 @@ export function infoMetricsSuccess(logger: Logger): void {
 
 export function infoMetricsThreadExited(logger: Logger): void {
   logger.info(getSdkErrMsg(7001));
+}
+
+export function infoTargetMetricsExceeded(logger: Logger): void {
+  logger.info(getSdkErrMsg(7004));
+}
+
+export function infoEvaluationMetricsExceeded(logger: Logger): void {
+  logger.info(getSdkErrMsg(7007));
 }
 
 export function debugEvalSuccess(

--- a/src/sdk_codes.ts
+++ b/src/sdk_codes.ts
@@ -109,12 +109,12 @@ export function infoMetricsThreadExited(logger: Logger): void {
   logger.info(getSdkErrMsg(7001));
 }
 
-export function infoTargetMetricsExceeded(logger: Logger): void {
-  logger.info(getSdkErrMsg(7004));
+export function warnTargetMetricsExceeded(logger: Logger): void {
+  logger.warn(getSdkErrMsg(7004));
 }
 
-export function infoEvaluationMetricsExceeded(logger: Logger): void {
-  logger.info(getSdkErrMsg(7007));
+export function warnEvaluationMetricsExceeded(logger: Logger): void {
+  logger.warn(getSdkErrMsg(7007));
 }
 
 export function debugEvalSuccess(


### PR DESCRIPTION
# What
- Splits evaluation and target metrics into their own caches:
    -  so that we can track target metrics correctly. Due to the fact we use the `globalTarget` , this meant that we would miss targets if the evaluation didn't change. 
    - Implements limits: Evaluation metrics to 10K unique evaluations--where a unique evaluation is flag + variation--this allows for evaluation for 10k flags with 5 variations each
    - Target metrics for 100K unique targets
    
- Implement seen targets:
    - ensures that the metrics service only gets sent target metrics for a target once, for the lifetime of the SDK instance
    - ensures that the SDK processes truly unique targets fairly, and that old targets don't occupy the 100K limit set per interval

# Testing
- Metrics accuracy:
    - TestGrid metrics tests
    - Manual sample app
    - Non-anonymous targets appear in UI
    - Anonymous targets don't appear in UI
- SeenTargets:
    - The same target won't be sent on the next interval if it is evaluated against
- Limits:
    - Sent 101K unique targets, only 100K get processed
