### PR TITLE
[FFM-11243] - Target v2: Adding support for AND/OR in clauses

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -238,7 +238,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Evaluation'
-  '/metrics/{environment}':
+  '/metrics/{environmentUUID}':
     post:
       tags:
         - metrics
@@ -254,6 +254,7 @@ paths:
             schema:
               $ref: '#/components/schemas/Metrics'
       security:
+        - ApiKeyAuth: []
         - BearerAuth: []
       responses:
         '200':
@@ -305,61 +306,93 @@ components:
   schemas:
     FeatureState:
       type: string
+      description: The state of a flag either off or on
       enum:
         - 'on'
         - 'off'
     Variation:
       type: object
+      description: A variation of a flag that can be returned to a target
       properties:
         identifier:
           type: string
+          description: The unique identifier for the variation
+          example: off-variation
         value:
           type: string
+          description: >-
+            The variation value to serve such as true or false for a boolean
+            flag
+          example: 'true'
         name:
           type: string
+          description: The user friendly name of the variation
+          example: Off VAriation
         description:
           type: string
+          description: A description of the variation
       required:
         - identifier
         - value
     Clause:
       type: object
+      description: A clause describes what conditions are used to evaluate a flag
       properties:
         id:
           type: string
+          description: The unique ID for the clause
+          example: 32434243
         attribute:
           type: string
+          description: >-
+            The attribute to use in the clause.  This can be any target
+            attribute
+          example: identifier
         op:
           type: string
+          description: 'The type of operation such as equals, starts_with, contains'
+          example: starts_with
         values:
           type: array
+          description: The values that are compared against the operator
           items:
             type: string
         negate:
           type: boolean
+          description: Is the operation negated?
+          example: false
       required:
-        - id
         - attribute
         - op
         - negate
         - values
     WeightedVariation:
       type: object
+      description: >-
+        A variation and the weighting it should receive as part of a percentage
+        rollout
       properties:
         variation:
           type: string
+          description: The variation identifier
+          example: off-variation
         weight:
           type: integer
+          description: The weight to be given to the variation in percent
+          example: 50
       required:
         - variation
         - weight
     Distribution:
       type: object
+      description: Describes a distribution rule
       properties:
         bucketBy:
           type: string
+          description: The attribute to use when distributing targets across buckets
         variations:
           type: array
+          description: A list of variations and the weight that should be given to each
           items:
             $ref: '#/components/schemas/WeightedVariation'
       required:
@@ -367,6 +400,9 @@ components:
         - variations
     Serve:
       type: object
+      description: >-
+        Describe the distribution rule and the variation that should be served
+        to the target
       properties:
         distribution:
           $ref: '#/components/schemas/Distribution'
@@ -374,13 +410,20 @@ components:
           type: string
     ServingRule:
       type: object
+      description: The rule used to determine what variation to serve to a target
       properties:
         ruleId:
           type: string
+          description: The unique identifier for this rule
         priority:
           type: integer
+          description: >-
+            The rules priority relative to other rules.  The rules are evaluated
+            in order with 1 being the highest
+          example: 1
         clauses:
           type: array
+          description: A list of clauses to use in the rule
           items:
             $ref: '#/components/schemas/Clause'
         serve:
@@ -389,14 +432,16 @@ components:
         - priority
         - clauses
         - serve
-        - ruleId
     Prerequisite:
       type: object
+      description: Feature Flag pre-requisites
       properties:
         feature:
           type: string
+          description: The feature identifier that is the prerequisite
         variations:
           type: array
+          description: A list of variations that must be met
           items:
             type: string
       required:
@@ -404,25 +449,35 @@ components:
         - variations
     TargetMap:
       type: object
+      description: Target map provides the details of a target that belongs to a flag
       properties:
         identifier:
           type: string
+          description: The identifier for the target
         name:
           type: string
+          description: The name of the target
       required:
-        - idenfifier
+        - identifier
         - name
     VariationMap:
       type: object
+      description: >-
+        A mapping of variations to targets and target groups (segments).  The
+        targets listed here should receive this variation.
       properties:
         variation:
           type: string
+          description: The variation identifier
+          example: off-variation
         targets:
           type: array
+          description: A list of target mappings
           items:
             $ref: '#/components/schemas/TargetMap'
         targetSegments:
           type: array
+          description: A list of target groups (segments)
           items:
             type: string
       required:
@@ -476,86 +531,123 @@ components:
         - state
         - kind
         - variations
-        - defaultTarget
         - offVariation
         - defaultServe
     Tag:
       type: object
-      description: A name and value pair.
+      description: A Tag object used to tag feature flags - consists of name and identifier
       properties:
         name:
           type: string
-        value:
+          description: The name of the tag
+          example: feature-flag-tag-1
+        identifier:
           type: string
+          description: The identifier of the tag
+          example: feature-flag-tag-1
       required:
         - name
+        - identifier
     Segment:
       type: object
+      description: A Target Group (Segment) response
       properties:
         identifier:
           type: string
-          description: Unique identifier for the segment.
+          description: Unique identifier for the target group.
         name:
           type: string
-          description: Name of the segment.
+          description: Name of the target group.
           example: Beta Testers
         environment:
           type: string
+          description: The environment this target group belongs to
+          example: Production
         tags:
           type: array
+          description: Tags for this target group
           items:
             $ref: '#/components/schemas/Tag'
         included:
           type: array
+          description: A list of Targets who belong to this target group
           items:
             $ref: '#/components/schemas/Target'
         excluded:
           type: array
+          description: A list of Targets who are excluded from this target group
           items:
             $ref: '#/components/schemas/Target'
         rules:
           type: array
           items:
             $ref: '#/components/schemas/Clause'
+        servingRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/GroupServingRule'
           description: >-
             An array of rules that can cause a user to be included in this
             segment.
         createdAt:
           type: integer
+          description: The data and time in milliseconds when the group was created
           format: int64
         modifiedAt:
           type: integer
+          description: The data and time in milliseconds when the group was last modified
           format: int64
         version:
           type: integer
+          description: >-
+            The version of this group.  Each time it is modified the version is
+            incremented
+          example: 1
           format: int64
       required:
         - identifier
         - name
     Target:
       type: object
+      description: A Target object
       properties:
         identifier:
           type: string
+          description: The unique identifier for this target
+          example: john-doe
         account:
           type: string
+          description: The account ID that the target belongs to
+          example: abcXDdffdaffd
         org:
           type: string
+          description: The identifier for the organization that the target belongs to
         environment:
           type: string
+          description: The identifier for the environment that the target belongs to
         project:
           type: string
+          description: The identifier for the project that this target belongs to
         name:
           type: string
+          description: The name of this Target
+          example: John Doe
         anonymous:
           type: boolean
+          description: Indicates if this target is anonymous
         attributes:
           type: object
+          description: a JSON representation of the attributes for this target
+          example:
+            age: 20
+            location: Belfast
         createdAt:
           type: integer
+          description: The date and time in milliseconds when this Target was created
           format: int64
         segments:
           type: array
+          description: A list of Target Groups (Segments) that this Target belongs to
           items:
             $ref: '#/components/schemas/Segment'
       required:
@@ -565,13 +657,42 @@ components:
         - project
         - account
         - org
+    GroupServingRule:
+      type: object
+      description: The rule used to determine what variation to serve to a target
+      properties:
+        ruleId:
+          type: string
+          description: The unique identifier for this rule
+        priority:
+          type: integer
+          description: >-
+            The rules priority relative to other rules.  The rules are evaluated
+            in order with 1 being the highest
+          example: 1
+        clauses:
+          type: array
+          description: A list of clauses to use in the rule
+          items:
+            $ref: '#/components/schemas/Clause'
+      required:
+        - ruleId
+        - clauses
+        - priority
     Error:
       type: object
       properties:
         code:
           type: string
+          description: The http error code
+          example: 404
         message:
           type: string
+          description: The reason the request failed
+          example: 'Error retrieving projects, organization ''default_org'' does not exist'
+        details:
+          type: object
+          description: Additional details about the error
       required:
         - code
         - message
@@ -608,16 +729,25 @@ components:
       properties:
         version:
           type: integer
+          description: >-
+            The version of this object.  The version will be incremented each
+            time the object is modified
+          example: 5
         pageCount:
           type: integer
+          description: The total number of pages
+          example: 100
         itemCount:
           type: integer
+          description: The total number of items
           example: 1
         pageSize:
           type: integer
+          description: The number of items per page
           example: 1
         pageIndex:
           type: integer
+          description: The current page
           example: 0
       required:
         - pageCount
@@ -704,6 +834,10 @@ components:
           items:
             $ref: '#/components/schemas/MetricsData'
   securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: api-key
     BearerAuth:
       type: http
       scheme: bearer
@@ -717,12 +851,26 @@ components:
       schema:
         type: string
     environmentPathParam:
-      name: environment
+      name: environmentUUID
       in: path
       required: true
       description: environment parameter in query.
       schema:
         type: string
+    pageNumber:
+      name: pageNumber
+      in: query
+      required: false
+      description: PageNumber
+      schema:
+        type: integer
+    pageSize:
+      name: pageSize
+      in: query
+      required: false
+      description: PageSize
+      schema:
+        type: integer
   responses:
     Unauthenticated:
       description: Unauthenticated
@@ -744,6 +892,12 @@ components:
             $ref: '#/components/schemas/Error'
     InternalServerError:
       description: Internal server error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    BadRequest:
+      description: Bad request
       content:
         application/json:
           schema:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-nodejs-server-sdk",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Feature flags SDK for NodeJS environments",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/src/__tests__/evaluator.test.ts
+++ b/src/__tests__/evaluator.test.ts
@@ -233,7 +233,6 @@ describe('Evaluator', () => {
       flagName,
       target,
       !expected,
-      null,
     );
 
     expect(result).toEqual(expected);

--- a/src/__tests__/evaluator.test.ts
+++ b/src/__tests__/evaluator.test.ts
@@ -1,16 +1,24 @@
 import { Evaluator } from '../evaluator';
 import { Logger } from '../log';
+import { SimpleCache } from '../cache';
+import { StorageRepository } from '../repository';
+import {
+  FeatureConfig,
+  FeatureConfigKindEnum,
+  FeatureState,
+  Segment,
+} from '../openapi';
+
+const logger: Logger = {
+  trace: jest.fn(),
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
 
 describe('Evaluator', () => {
   it('should fallback to identifier if bucketby attribute does not exist', async () => {
-    const logger: Logger = {
-      trace: jest.fn(),
-      debug: jest.fn(),
-      info: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-    };
-
     const mock_query = {
       getFlag: jest.fn(),
       getSegment: jest.fn(),
@@ -76,5 +84,158 @@ describe('Evaluator', () => {
     );
 
     expect(actual_variation).toEqual('wanted_value');
+  });
+
+  test.each([
+    // if (target.attr.email endswith '@harness.io' && target.attr.role = 'developer')
+    ['email_is_dev', 'boolflag_and', 'user@harness.io', 'developer', true],
+    ['email_is_mgr', 'boolflag_and', 'user@harness.io', 'manager', false],
+    ['ext_email_is_dev', 'boolflag_and', 'user@gmail.com', 'developer', false],
+    ['ext_email_is_mgr', 'boolflag_and', 'user@gmail.com', 'manager', false],
+    // if (target.attr.email endswith '@harness.io' || target.attr.email endswith '@somethingelse.com')
+    ['email_is_harness', 'boolflag_or', 'user@harness.io', 'n/a', true],
+    ['email_is_other', 'boolflag_or', 'user@somethingelse.com', 'n/a', true],
+    ['email_is_gmail', 'boolflag_or', 'user@gmail.com', 'n/a', false],
+  ])('Target rules v2 %s_%s', async (name, flagName, email, role, expected) => {
+    async function loadFlags(repo: StorageRepository) {
+      const feature_config_or: FeatureConfig = {
+        feature: 'boolflag_or',
+        defaultServe: { variation: 'false' },
+        environment: 'test',
+        kind: FeatureConfigKindEnum.Boolean,
+        offVariation: 'false',
+        project: 'test',
+        state: FeatureState.On,
+        variationToTargetMap: [
+          { variation: 'true', targets: [], targetSegments: ['or-segment'] },
+        ],
+        variations: [
+          { identifier: 'true', name: 'True', value: 'true' },
+          { identifier: 'false', name: 'False', value: 'false' },
+        ],
+        version: 1,
+      };
+
+      const feature_config_and: FeatureConfig = {
+        feature: 'boolflag_and',
+        defaultServe: { variation: 'false' },
+        environment: 'test',
+        kind: FeatureConfigKindEnum.Boolean,
+        offVariation: 'false',
+        project: 'test',
+        state: FeatureState.On,
+        variationToTargetMap: [
+          { variation: 'true', targets: [], targetSegments: ['and-segment'] },
+        ],
+        variations: [
+          { identifier: 'true', name: 'True', value: 'true' },
+          { identifier: 'false', name: 'False', value: 'false' },
+        ],
+        version: 1,
+      };
+
+      await repo.setFlag('boolflag_or', feature_config_or);
+      await repo.setFlag('boolflag_and', feature_config_and);
+    }
+    async function loadSegments(repo: StorageRepository) {
+      const segment_or: Segment = {
+        identifier: 'or-segment',
+        name: 'is_harness_or_somethingelse_email_OR',
+        environment: 'Production',
+        // only 1 servingRules needs to be true (OR)
+        servingRules: [
+          {
+            ruleId: 'this_or_rule_with_lower_priority_should_be_ignored',
+            priority: 7,
+            clauses: [
+              {
+                attribute: 'email',
+                op: 'ends_with',
+                values: ['@harness.io'],
+                negate: false,
+              },
+            ],
+          },
+          {
+            ruleId: 'rule1',
+            priority: 1,
+            clauses: [
+              {
+                attribute: 'email',
+                op: 'ends_with',
+                values: ['@harness.io'],
+                negate: false,
+              },
+            ],
+          },
+          {
+            ruleId: 'rule2',
+            priority: 2,
+            clauses: [
+              {
+                attribute: 'email',
+                op: 'ends_with',
+                values: ['@somethingelse.com'],
+                negate: false,
+              },
+            ],
+          },
+        ],
+        version: 2,
+      };
+      const segment_and: Segment = {
+        identifier: 'and-segment',
+        name: 'is_a_harness_developer_test_AND',
+        environment: 'Production',
+        servingRules: [
+          {
+            ruleId: 'rule1',
+            priority: 1,
+            // all clauses need to be true (AND)
+            clauses: [
+              {
+                attribute: 'email',
+                op: 'ends_with',
+                values: ['@harness.io'],
+                negate: false,
+              },
+              {
+                attribute: 'role',
+                op: 'equal',
+                values: ['developer'],
+                negate: false,
+              },
+            ],
+          },
+        ],
+      };
+      await repo.setSegment('or-segment', segment_or);
+      await repo.setSegment('and-segment', segment_and);
+    }
+
+    const cache = new SimpleCache();
+    const repository = new StorageRepository(cache);
+    const evaluator = new Evaluator(repository, logger);
+
+    await loadFlags(repository);
+    await loadSegments(repository);
+
+    const target = {
+      identifier: name,
+      name: name,
+      attributes: {
+        email: email,
+        role: role,
+      },
+    };
+
+    const result = await evaluator.boolVariation(
+      flagName,
+      target,
+      !expected,
+      null,
+    );
+
+    expect(result).toEqual(expected);
   });
 });

--- a/src/__tests__/evaluator.test.ts
+++ b/src/__tests__/evaluator.test.ts
@@ -86,155 +86,156 @@ describe('Evaluator', () => {
     expect(actual_variation).toEqual('wanted_value');
   });
 
-  test.each([
-    // if (target.attr.email endswith '@harness.io' && target.attr.role = 'developer')
-    ['email_is_dev', 'boolflag_and', 'user@harness.io', 'developer', true],
-    ['email_is_mgr', 'boolflag_and', 'user@harness.io', 'manager', false],
-    ['ext_email_is_dev', 'boolflag_and', 'user@gmail.com', 'developer', false],
-    ['ext_email_is_mgr', 'boolflag_and', 'user@gmail.com', 'manager', false],
-    // if (target.attr.email endswith '@harness.io' || target.attr.email endswith '@somethingelse.com')
-    ['email_is_harness', 'boolflag_or', 'user@harness.io', 'n/a', true],
-    ['email_is_other', 'boolflag_or', 'user@somethingelse.com', 'n/a', true],
-    ['email_is_gmail', 'boolflag_or', 'user@gmail.com', 'n/a', false],
-  ])('Target rules v2 %s_%s', async (name, flagName, email, role, expected) => {
-    async function loadFlags(repo: StorageRepository) {
-      const feature_config_or: FeatureConfig = {
-        feature: 'boolflag_or',
-        defaultServe: { variation: 'false' },
-        environment: 'test',
-        kind: FeatureConfigKindEnum.Boolean,
-        offVariation: 'false',
-        project: 'test',
-        state: FeatureState.On,
-        variationToTargetMap: [
-          { variation: 'true', targets: [], targetSegments: ['or-segment'] },
-        ],
-        variations: [
-          { identifier: 'true', name: 'True', value: 'true' },
-          { identifier: 'false', name: 'False', value: 'false' },
-        ],
-        version: 1,
-      };
-
-      const feature_config_and: FeatureConfig = {
-        feature: 'boolflag_and',
-        defaultServe: { variation: 'false' },
-        environment: 'test',
-        kind: FeatureConfigKindEnum.Boolean,
-        offVariation: 'false',
-        project: 'test',
-        state: FeatureState.On,
-        variationToTargetMap: [
-          { variation: 'true', targets: [], targetSegments: ['and-segment'] },
-        ],
-        variations: [
-          { identifier: 'true', name: 'True', value: 'true' },
-          { identifier: 'false', name: 'False', value: 'false' },
-        ],
-        version: 1,
-      };
-
-      await repo.setFlag('boolflag_or', feature_config_or);
-      await repo.setFlag('boolflag_and', feature_config_and);
-    }
-    async function loadSegments(repo: StorageRepository) {
-      const segment_or: Segment = {
-        identifier: 'or-segment',
-        name: 'is_harness_or_somethingelse_email_OR',
-        environment: 'Production',
-        // only 1 servingRules needs to be true (OR)
-        servingRules: [
-          {
-            ruleId: 'this_or_rule_with_lower_priority_should_be_ignored',
-            priority: 7,
-            clauses: [
-              {
-                attribute: 'email',
-                op: 'ends_with',
-                values: ['@harness.io'],
-                negate: false,
-              },
-            ],
-          },
-          {
-            ruleId: 'rule1',
-            priority: 1,
-            clauses: [
-              {
-                attribute: 'email',
-                op: 'ends_with',
-                values: ['@harness.io'],
-                negate: false,
-              },
-            ],
-          },
-          {
-            ruleId: 'rule2',
-            priority: 2,
-            clauses: [
-              {
-                attribute: 'email',
-                op: 'ends_with',
-                values: ['@somethingelse.com'],
-                negate: false,
-              },
-            ],
-          },
-        ],
-        version: 2,
-      };
-      const segment_and: Segment = {
-        identifier: 'and-segment',
-        name: 'is_a_harness_developer_test_AND',
-        environment: 'Production',
-        servingRules: [
-          {
-            ruleId: 'rule1',
-            priority: 1,
-            // all clauses need to be true (AND)
-            clauses: [
-              {
-                attribute: 'email',
-                op: 'ends_with',
-                values: ['@harness.io'],
-                negate: false,
-              },
-              {
-                attribute: 'role',
-                op: 'equal',
-                values: ['developer'],
-                negate: false,
-              },
-            ],
-          },
-        ],
-      };
-      await repo.setSegment('or-segment', segment_or);
-      await repo.setSegment('and-segment', segment_and);
-    }
-
-    const cache = new SimpleCache();
-    const repository = new StorageRepository(cache);
-    const evaluator = new Evaluator(repository, logger);
-
-    await loadFlags(repository);
-    await loadSegments(repository);
-
-    const target = {
-      identifier: name,
-      name,
-      attributes: {
-        email,
-        role,
-      },
+  async function loadFlags(repo: StorageRepository) {
+    const featureConfigOr: FeatureConfig = {
+      feature: 'boolflag_or',
+      defaultServe: { variation: 'false' },
+      environment: 'test',
+      kind: FeatureConfigKindEnum.Boolean,
+      offVariation: 'false',
+      project: 'test',
+      state: FeatureState.On,
+      variationToTargetMap: [
+        { variation: 'true', targets: [], targetSegments: ['or-segment'] },
+      ],
+      variations: [
+        { identifier: 'true', name: 'True', value: 'true' },
+        { identifier: 'false', name: 'False', value: 'false' },
+      ],
+      version: 1,
     };
 
-    const result = await evaluator.boolVariation(
-      flagName,
-      target,
-      !expected,
-    );
+    const featureConfigAnd: FeatureConfig = {
+      feature: 'boolflag_and',
+      defaultServe: { variation: 'false' },
+      environment: 'test',
+      kind: FeatureConfigKindEnum.Boolean,
+      offVariation: 'false',
+      project: 'test',
+      state: FeatureState.On,
+      variationToTargetMap: [
+        { variation: 'true', targets: [], targetSegments: ['and-segment'] },
+      ],
+      variations: [
+        { identifier: 'true', name: 'True', value: 'true' },
+        { identifier: 'false', name: 'False', value: 'false' },
+      ],
+      version: 1,
+    };
 
-    expect(result).toEqual(expected);
-  });
+    await repo.setFlag('boolflag_or', featureConfigOr);
+    await repo.setFlag('boolflag_and', featureConfigAnd);
+  }
+  async function loadSegments(repo: StorageRepository) {
+    const segmentOr: Segment = {
+      identifier: 'or-segment',
+      name: 'is_harness_or_somethingelse_email_OR',
+      environment: 'Production',
+      // only 1 servingRules needs to be true (OR)
+      servingRules: [
+        {
+          ruleId: 'this_or_rule_with_lower_priority_should_be_ignored',
+          priority: 7,
+          clauses: [
+            {
+              attribute: 'email',
+              op: 'ends_with',
+              values: ['@harness.io'],
+              negate: false,
+            },
+          ],
+        },
+        {
+          ruleId: 'rule1',
+          priority: 1,
+          clauses: [
+            {
+              attribute: 'email',
+              op: 'ends_with',
+              values: ['@harness.io'],
+              negate: false,
+            },
+          ],
+        },
+        {
+          ruleId: 'rule2',
+          priority: 2,
+          clauses: [
+            {
+              attribute: 'email',
+              op: 'ends_with',
+              values: ['@somethingelse.com'],
+              negate: false,
+            },
+          ],
+        },
+      ],
+      version: 2,
+    };
+
+    const segmentAnd: Segment = {
+      identifier: 'and-segment',
+      name: 'is_a_harness_developer_test_AND',
+      environment: 'Production',
+      servingRules: [
+        {
+          ruleId: 'rule1',
+          priority: 1,
+          // all clauses need to be true (AND)
+          clauses: [
+            {
+              attribute: 'email',
+              op: 'ends_with',
+              values: ['@harness.io'],
+              negate: false,
+            },
+            {
+              attribute: 'role',
+              op: 'equal',
+              values: ['developer'],
+              negate: false,
+            },
+          ],
+        },
+      ],
+    };
+
+    await repo.setSegment('or-segment', segmentOr);
+    await repo.setSegment('and-segment', segmentAnd);
+  }
+
+  test.each([
+    // if (target.attr.email endswith '@harness.io' && target.attr.role = 'developer')
+    ['boolflag_and', true, 'user@harness.io', 'developer'],
+    ['boolflag_and', false, 'user@harness.io', 'manager'],
+    ['boolflag_and', false, 'user@gmail.com', 'developer'],
+    ['boolflag_and', false, 'user@gmail.com', 'manager'],
+    // if (target.attr.email endswith '@harness.io' || target.attr.email endswith '@somethingelse.com')
+    ['boolflag_or', true, 'user@harness.io', 'n/a'],
+    ['boolflag_or', true, 'user@somethingelse.com', 'n/a'],
+    ['boolflag_or', false, 'user@gmail.com', 'n/a'],
+  ])(
+    'Flag %s should evaluate to %s when target email=%s role=%s',
+    async (flagName, expected, email, role) => {
+      const cache = new SimpleCache();
+      const repository = new StorageRepository(cache);
+      const evaluator = new Evaluator(repository, logger);
+
+      await loadFlags(repository);
+      await loadSegments(repository);
+
+      const target = {
+        identifier: 'test',
+        name: 'test',
+        attributes: {
+          email,
+          role,
+        },
+      };
+
+      const result = await evaluator.boolVariation(flagName, target, !expected);
+
+      expect(result).toEqual(expected);
+    },
+  );
 });

--- a/src/__tests__/evaluator.test.ts
+++ b/src/__tests__/evaluator.test.ts
@@ -222,10 +222,10 @@ describe('Evaluator', () => {
 
     const target = {
       identifier: name,
-      name: name,
+      name,
       attributes: {
-        email: email,
-        role: role,
+        email,
+        role,
       },
     };
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -152,13 +152,11 @@ export class Evaluator {
           return true;
         }
 
-        if (!!segment?.servingRules?.length) {
+        if (segment?.servingRules?.length) {
           // Use enhanced rules first if they're available
-          const sortedServingRules = segment.servingRules.sort(
-            (r1, r2) => r1.priority - r2.priority,
-          );
+          segment.servingRules.sort((r1, r2) => r1.priority - r2.priority);
 
-          for (const servingRule of sortedServingRules) {
+          for (const servingRule of segment.servingRules) {
             if (await this.evaluateClauses_v2(servingRule.clauses, target)) {
               return true;
             }
@@ -246,6 +244,10 @@ export class Evaluator {
     clauses: Clause[],
     target: Target,
   ): Promise<boolean> {
+    if (!clauses.length) {
+      return false;
+    }
+
     for (const clause of clauses) {
       if (!(await this.evaluateClause(clause, target))) {
         // first clause to false, short-circuit and exit with false

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -152,7 +152,7 @@ export class Evaluator {
           return true;
         }
 
-        if (segment.servingRules && segment.servingRules.length > 0) {
+        if (!!segment?.servingRules?.length) {
           // Use enhanced rules first if they're available
           const sortedServingRules = segment.servingRules.sort(
             (r1, r2) => r1.priority - r2.priority,

--- a/src/openapi/api.ts
+++ b/src/openapi/api.ts
@@ -85,56 +85,56 @@ export interface AuthenticationResponse {
     authToken: string;
 }
 /**
- * 
+ * A clause describes what conditions are used to evaluate a flag
  * @export
  * @interface Clause
  */
 export interface Clause {
     /**
-     * 
+     * The unique ID for the clause
      * @type {string}
      * @memberof Clause
      */
-    id: string;
+    id?: string;
     /**
-     * 
+     * The attribute to use in the clause.  This can be any target attribute
      * @type {string}
      * @memberof Clause
      */
     attribute: string;
     /**
-     * 
+     * The type of operation such as equals, starts_with, contains
      * @type {string}
      * @memberof Clause
      */
     op: string;
     /**
-     * 
+     * The values that are compared against the operator
      * @type {Array<string>}
      * @memberof Clause
      */
     values: Array<string>;
     /**
-     * 
+     * Is the operation negated?
      * @type {boolean}
      * @memberof Clause
      */
     negate: boolean;
 }
 /**
- * 
+ * Describes a distribution rule
  * @export
  * @interface Distribution
  */
 export interface Distribution {
     /**
-     * 
+     * The attribute to use when distributing targets across buckets
      * @type {string}
      * @memberof Distribution
      */
     bucketBy: string;
     /**
-     * 
+     * A list of variations and the weight that should be given to each
      * @type {Array<WeightedVariation>}
      * @memberof Distribution
      */
@@ -263,7 +263,7 @@ export enum FeatureConfigKindEnum {
 }
 
 /**
- * 
+ * The state of a flag either off or on
  * @export
  * @enum {string}
  */
@@ -273,6 +273,31 @@ export enum FeatureState {
     Off = 'off'
 }
 
+/**
+ * The rule used to determine what variation to serve to a target
+ * @export
+ * @interface GroupServingRule
+ */
+export interface GroupServingRule {
+    /**
+     * The unique identifier for this rule
+     * @type {string}
+     * @memberof GroupServingRule
+     */
+    ruleId: string;
+    /**
+     * The rules priority relative to other rules.  The rules are evaluated in order with 1 being the highest
+     * @type {number}
+     * @memberof GroupServingRule
+     */
+    priority: number;
+    /**
+     * A list of clauses to use in the rule
+     * @type {Array<Clause>}
+     * @memberof GroupServingRule
+     */
+    clauses: Array<Clause>;
+}
 /**
  * 
  * @export
@@ -358,17 +383,23 @@ export enum MetricsDataMetricsTypeEnum {
  */
 export interface ModelError {
     /**
-     * 
+     * The http error code
      * @type {string}
      * @memberof ModelError
      */
     code: string;
     /**
-     * 
+     * The reason the request failed
      * @type {string}
      * @memberof ModelError
      */
     message: string;
+    /**
+     * Additional details about the error
+     * @type {object}
+     * @memberof ModelError
+     */
+    details?: object;
 }
 /**
  * 
@@ -377,124 +408,130 @@ export interface ModelError {
  */
 export interface Pagination {
     /**
-     * 
+     * The version of this object.  The version will be incremented each time the object is modified
      * @type {number}
      * @memberof Pagination
      */
     version?: number;
     /**
-     * 
+     * The total number of pages
      * @type {number}
      * @memberof Pagination
      */
     pageCount: number;
     /**
-     * 
+     * The total number of items
      * @type {number}
      * @memberof Pagination
      */
     itemCount: number;
     /**
-     * 
+     * The number of items per page
      * @type {number}
      * @memberof Pagination
      */
     pageSize: number;
     /**
-     * 
+     * The current page
      * @type {number}
      * @memberof Pagination
      */
     pageIndex: number;
 }
 /**
- * 
+ * Feature Flag pre-requisites
  * @export
  * @interface Prerequisite
  */
 export interface Prerequisite {
     /**
-     * 
+     * The feature identifier that is the prerequisite
      * @type {string}
      * @memberof Prerequisite
      */
     feature: string;
     /**
-     * 
+     * A list of variations that must be met
      * @type {Array<string>}
      * @memberof Prerequisite
      */
     variations: Array<string>;
 }
 /**
- * 
+ * A Target Group (Segment) response
  * @export
  * @interface Segment
  */
 export interface Segment {
     /**
-     * Unique identifier for the segment.
+     * Unique identifier for the target group.
      * @type {string}
      * @memberof Segment
      */
     identifier: string;
     /**
-     * Name of the segment.
+     * Name of the target group.
      * @type {string}
      * @memberof Segment
      */
     name: string;
     /**
-     * 
+     * The environment this target group belongs to
      * @type {string}
      * @memberof Segment
      */
     environment?: string;
     /**
-     * 
+     * Tags for this target group
      * @type {Array<Tag>}
      * @memberof Segment
      */
     tags?: Array<Tag>;
     /**
-     * 
+     * A list of Targets who belong to this target group
      * @type {Array<Target>}
      * @memberof Segment
      */
     included?: Array<Target>;
     /**
-     * 
+     * A list of Targets who are excluded from this target group
      * @type {Array<Target>}
      * @memberof Segment
      */
     excluded?: Array<Target>;
     /**
-     * An array of rules that can cause a user to be included in this segment.
+     * 
      * @type {Array<Clause>}
      * @memberof Segment
      */
     rules?: Array<Clause>;
     /**
-     * 
+     * An array of rules that can cause a user to be included in this segment.
+     * @type {Array<GroupServingRule>}
+     * @memberof Segment
+     */
+    servingRules?: Array<GroupServingRule>;
+    /**
+     * The data and time in milliseconds when the group was created
      * @type {number}
      * @memberof Segment
      */
     createdAt?: number;
     /**
-     * 
+     * The data and time in milliseconds when the group was last modified
      * @type {number}
      * @memberof Segment
      */
     modifiedAt?: number;
     /**
-     * 
+     * The version of this group.  Each time it is modified the version is incremented
      * @type {number}
      * @memberof Segment
      */
     version?: number;
 }
 /**
- * 
+ * Describe the distribution rule and the variation that should be served to the target
  * @export
  * @interface Serve
  */
@@ -513,25 +550,25 @@ export interface Serve {
     variation?: string;
 }
 /**
- * 
+ * The rule used to determine what variation to serve to a target
  * @export
  * @interface ServingRule
  */
 export interface ServingRule {
     /**
-     * 
+     * The unique identifier for this rule
      * @type {string}
      * @memberof ServingRule
      */
-    ruleId: string;
+    ruleId?: string;
     /**
-     * 
+     * The rules priority relative to other rules.  The rules are evaluated in order with 1 being the highest
      * @type {number}
      * @memberof ServingRule
      */
     priority: number;
     /**
-     * 
+     * A list of clauses to use in the rule
      * @type {Array<Clause>}
      * @memberof ServingRule
      */
@@ -544,86 +581,86 @@ export interface ServingRule {
     serve: Serve;
 }
 /**
- * A name and value pair.
+ * A Tag object used to tag feature flags - consists of name and identifier
  * @export
  * @interface Tag
  */
 export interface Tag {
     /**
-     * 
+     * The name of the tag
      * @type {string}
      * @memberof Tag
      */
     name: string;
     /**
-     * 
+     * The identifier of the tag
      * @type {string}
      * @memberof Tag
      */
-    value?: string;
+    identifier: string;
 }
 /**
- * 
+ * A Target object
  * @export
  * @interface Target
  */
 export interface Target {
     /**
-     * 
+     * The unique identifier for this target
      * @type {string}
      * @memberof Target
      */
     identifier: string;
     /**
-     * 
+     * The account ID that the target belongs to
      * @type {string}
      * @memberof Target
      */
     account: string;
     /**
-     * 
+     * The identifier for the organization that the target belongs to
      * @type {string}
      * @memberof Target
      */
     org: string;
     /**
-     * 
+     * The identifier for the environment that the target belongs to
      * @type {string}
      * @memberof Target
      */
     environment: string;
     /**
-     * 
+     * The identifier for the project that this target belongs to
      * @type {string}
      * @memberof Target
      */
     project: string;
     /**
-     * 
+     * The name of this Target
      * @type {string}
      * @memberof Target
      */
     name: string;
     /**
-     * 
+     * Indicates if this target is anonymous
      * @type {boolean}
      * @memberof Target
      */
     anonymous?: boolean;
     /**
-     * 
+     * a JSON representation of the attributes for this target
      * @type {object}
      * @memberof Target
      */
     attributes?: object;
     /**
-     * 
+     * The date and time in milliseconds when this Target was created
      * @type {number}
      * @memberof Target
      */
     createdAt?: number;
     /**
-     * 
+     * A list of Target Groups (Segments) that this Target belongs to
      * @type {Array<Segment>}
      * @memberof Target
      */
@@ -655,94 +692,94 @@ export interface TargetData {
     attributes: Array<KeyValue>;
 }
 /**
- * 
+ * Target map provides the details of a target that belongs to a flag
  * @export
  * @interface TargetMap
  */
 export interface TargetMap {
     /**
-     * 
+     * The identifier for the target
      * @type {string}
      * @memberof TargetMap
      */
-    identifier?: string;
+    identifier: string;
     /**
-     * 
+     * The name of the target
      * @type {string}
      * @memberof TargetMap
      */
     name: string;
 }
 /**
- * 
+ * A variation of a flag that can be returned to a target
  * @export
  * @interface Variation
  */
 export interface Variation {
     /**
-     * 
+     * The unique identifier for the variation
      * @type {string}
      * @memberof Variation
      */
     identifier: string;
     /**
-     * 
+     * The variation value to serve such as true or false for a boolean flag
      * @type {string}
      * @memberof Variation
      */
     value: string;
     /**
-     * 
+     * The user friendly name of the variation
      * @type {string}
      * @memberof Variation
      */
     name?: string;
     /**
-     * 
+     * A description of the variation
      * @type {string}
      * @memberof Variation
      */
     description?: string;
 }
 /**
- * 
+ * A mapping of variations to targets and target groups (segments).  The targets listed here should receive this variation.
  * @export
  * @interface VariationMap
  */
 export interface VariationMap {
     /**
-     * 
+     * The variation identifier
      * @type {string}
      * @memberof VariationMap
      */
     variation: string;
     /**
-     * 
+     * A list of target mappings
      * @type {Array<TargetMap>}
      * @memberof VariationMap
      */
     targets?: Array<TargetMap>;
     /**
-     * 
+     * A list of target groups (segments)
      * @type {Array<string>}
      * @memberof VariationMap
      */
     targetSegments?: Array<string>;
 }
 /**
- * 
+ * A variation and the weighting it should receive as part of a percentage rollout
  * @export
  * @interface WeightedVariation
  */
 export interface WeightedVariation {
     /**
-     * 
+     * The variation identifier
      * @type {string}
      * @memberof WeightedVariation
      */
     variation: string;
     /**
-     * 
+     * The weight to be given to the variation in percent
      * @type {number}
      * @memberof WeightedVariation
      */
@@ -1454,17 +1491,17 @@ export const MetricsApiAxiosParamCreator = function (configuration?: Configurati
         /**
          * Send metrics to Analytics server
          * @summary Send metrics to the Analytics server.
-         * @param {string} environment environment parameter in query.
+         * @param {string} environmentUUID environment parameter in query.
          * @param {string} [cluster] Unique identifier for the cluster for the account
          * @param {Metrics} [metrics] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        postMetrics: async (environment: string, cluster?: string, metrics?: Metrics, options: any = {}): Promise<RequestArgs> => {
-            // verify required parameter 'environment' is not null or undefined
-            assertParamExists('postMetrics', 'environment', environment)
-            const localVarPath = `/metrics/{environment}`
-                .replace(`{${"environment"}}`, encodeURIComponent(String(environment)));
+        postMetrics: async (environmentUUID: string, cluster?: string, metrics?: Metrics, options: any = {}): Promise<RequestArgs> => {
+            // verify required parameter 'environmentUUID' is not null or undefined
+            assertParamExists('postMetrics', 'environmentUUID', environmentUUID)
+            const localVarPath = `/metrics/{environmentUUID}`
+                .replace(`{${"environmentUUID"}}`, encodeURIComponent(String(environmentUUID)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -1475,6 +1512,9 @@ export const MetricsApiAxiosParamCreator = function (configuration?: Configurati
             const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
+
+            // authentication ApiKeyAuth required
+            await setApiKeyToObject(localVarHeaderParameter, "api-key", configuration)
 
             // authentication BearerAuth required
             // http bearer authentication required
@@ -1511,14 +1551,14 @@ export const MetricsApiFp = function(configuration?: Configuration) {
         /**
          * Send metrics to Analytics server
          * @summary Send metrics to the Analytics server.
-         * @param {string} environment environment parameter in query.
+         * @param {string} environmentUUID environment parameter in query.
          * @param {string} [cluster] Unique identifier for the cluster for the account
          * @param {Metrics} [metrics] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async postMetrics(environment: string, cluster?: string, metrics?: Metrics, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.postMetrics(environment, cluster, metrics, options);
+        async postMetrics(environmentUUID: string, cluster?: string, metrics?: Metrics, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.postMetrics(environmentUUID, cluster, metrics, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1534,14 +1574,14 @@ export const MetricsApiFactory = function (configuration?: Configuration, basePa
         /**
          * Send metrics to Analytics server
          * @summary Send metrics to the Analytics server.
-         * @param {string} environment environment parameter in query.
+         * @param {string} environmentUUID environment parameter in query.
          * @param {string} [cluster] Unique identifier for the cluster for the account
          * @param {Metrics} [metrics] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        postMetrics(environment: string, cluster?: string, metrics?: Metrics, options?: any): AxiosPromise<void> {
-            return localVarFp.postMetrics(environment, cluster, metrics, options).then((request) => request(axios, basePath));
+        postMetrics(environmentUUID: string, cluster?: string, metrics?: Metrics, options?: any): AxiosPromise<void> {
+            return localVarFp.postMetrics(environmentUUID, cluster, metrics, options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1556,15 +1596,15 @@ export class MetricsApi extends BaseAPI {
     /**
      * Send metrics to Analytics server
      * @summary Send metrics to the Analytics server.
-     * @param {string} environment environment parameter in query.
+     * @param {string} environmentUUID environment parameter in query.
      * @param {string} [cluster] Unique identifier for the cluster for the account
      * @param {Metrics} [metrics] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof MetricsApi
      */
-    public postMetrics(environment: string, cluster?: string, metrics?: Metrics, options?: any) {
-        return MetricsApiFp(this.configuration).postMetrics(environment, cluster, metrics, options).then((request) => request(this.axios, this.basePath));
+    public postMetrics(environmentUUID: string, cluster?: string, metrics?: Metrics, options?: any) {
+        return MetricsApiFp(this.configuration).postMetrics(environmentUUID, cluster, metrics, options).then((request) => request(this.axios, this.basePath));
     }
 }
 


### PR DESCRIPTION
[FFM-11243] - Target v2: Adding support for AND/OR in clauses

**What**
Adding support for processing the new `GroupServingRule` in `Segment`. Also update API definition for OpenAPIGenerator plugin. The default behaviour now is to check for the existence of `GroupServingRule` if found then we ignore the old `Rules` section. Old `Rules` section will continue to work to aid transition if `GroupServingRule` is not yet populated. Each entry in `GroupServingRule` is ORed while each list of clauses is ANDed. The `GroupServingRule` with the highest priority used first to allow reordering on the backend.

**Why**
This gives the customer more flexibility on how they configure their rules in the backend.

**Testing**
Initial unit tests for now + testgrid for existing rules

[FFM-11243]: https://harness.atlassian.net/browse/FFM-11243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ