### PR TITLE
FFM-11364  Use target-segments v2-rule parameter

### DIFF
--- a/client-v1.yaml
+++ b/client-v1.yaml
@@ -14,6 +14,8 @@ servers:
 tags:
   - name: client
   - name: metrics
+  - name: Proxy
+    description: APIs used by the ff-proxy
 paths:
   '/client/env/{environmentUUID}/feature-configs':
     get:
@@ -85,6 +87,7 @@ paths:
           schema:
             type: string
         - $ref: '#/components/parameters/clusterQueryOptionalParam'
+        - $ref: '#/components/parameters/segmentRulesV2QueryParam'
       security:
         - BearerAuth: []
       responses:
@@ -125,6 +128,7 @@ paths:
           schema:
             type: string
         - $ref: '#/components/parameters/clusterQueryOptionalParam'
+        - $ref: '#/components/parameters/segmentRulesV2QueryParam'
       security:
         - BearerAuth: []
       responses:
@@ -199,10 +203,7 @@ paths:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/Pagination'
-                  - type: object
-                    properties:
-                      evaluations:
-                        $ref: '#/components/schemas/Evaluations'
+                  - $ref: '#/components/schemas/Evaluations'
   '/client/env/{environmentUUID}/target/{target}/evaluations/{feature}':
     get:
       summary: Get feature evaluations for target
@@ -302,6 +303,84 @@ paths:
                 default: '*'
         '503':
           description: Service Unavailable
+  /proxy/config:
+    get:
+      summary: Gets Proxy config for multiple environments
+      description: >-
+        Gets Proxy config for multiple environments if the Key query param is
+        provided or gets config for a single environment if an environment query
+        param is provided
+      operationId: GetProxyConfig
+      tags:
+        - Proxy
+      parameters:
+        - $ref: '#/components/parameters/pageNumber'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/clusterQueryOptionalParam'
+        - in: query
+          name: environment
+          description: >-
+            Accepts an EnvironmentID. If this is provided then the endpoint will
+            only return config for this environment. If this is left empty then
+            the Proxy will return config for all environments associated with
+            the Proxy Key.
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: key
+          description: Accpets a Proxy Key.
+          required: true
+          schema:
+            type: string
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          $ref: '#/components/responses/ProxyConfigResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '403':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /proxy/auth:
+    post:
+      summary: Endpoint that the Proxy can use to authenticate with the client server
+      description: Endpoint that the Proxy can use to authenticate with the client server
+      operationId: AuthenticateProxyKey
+      tags:
+        - Proxy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                proxyKey:
+                  type: string
+                  example: 896045f3-42ee-4e73-9154-086644768b96
+              required:
+                - proxyKey
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthenticationResponse'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '403':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
   schemas:
     FeatureState:
@@ -833,6 +912,31 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/MetricsData'
+    ProxyConfig:
+      type: object
+      description: TBD
+      allOf:
+        - $ref: '#/components/schemas/Pagination'
+        - properties:
+            environments:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  apiKeys:
+                    type: array
+                    items:
+                      type: string
+                  featureConfigs:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/FeatureConfig'
+                  segments:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Segment'
   securitySchemes:
     ApiKeyAuth:
       type: apiKey
@@ -848,6 +952,17 @@ components:
       in: query
       required: false
       description: Unique identifier for the cluster for the account
+      schema:
+        type: string
+    segmentRulesV2QueryParam:
+      name: rules
+      in: query
+      required: false
+      description: >-
+        When set to rules=v2 will return AND rule compatible serving_rules
+        field. When not set or set to any other value will return old rules
+        field only compatible with OR rules.
+      allowEmptyValue: true
       schema:
         type: string
     environmentPathParam:
@@ -896,6 +1011,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+    ProxyConfigResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ProxyConfig'
     BadRequest:
       description: Bad request
       content:

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "coverage": "jest --coverage",
     "test:junit": "jest --reporters=default --reporters=jest-junit",
     "test:watch": "jest --watch",
-    "generate": "openapi-generator-cli generate -i ./api.yaml -g typescript-axios -o src/openapi"
+    "generate": "openapi-generator-cli generate -i client-v1.yaml -g typescript-axios -o src/openapi"
   },
   "author": "Enver Bisevac <enver.bisevac@harness.io>",
   "license": "Apache-2.0",

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,13 +2,19 @@ import EventEmitter from 'events';
 import jwt_decode from 'jwt-decode';
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 import axiosRetry from 'axios-retry';
-import { Claims, Options, StreamEvent, Target } from './types';
+import {
+  APIConfiguration,
+  Claims,
+  Options,
+  StreamEvent,
+  Target,
+} from './types';
 import { Configuration, ClientApi, FeatureConfig, Variation } from './openapi';
 import { VERSION } from './version';
 import { PollerEvent, PollingProcessor } from './polling';
 import { StreamProcessor } from './streaming';
 import { Evaluator } from './evaluator';
-import { defaultOptions } from './constants';
+import { apiConfiguration, defaultOptions } from './constants';
 import { Repository, RepositoryEvent, StorageRepository } from './repository';
 import {
   MetricEvent,
@@ -55,6 +61,7 @@ export default class Client {
   private environment: string;
   private configuration: Configuration;
   private options: Options;
+  private apiConfiguration: APIConfiguration = apiConfiguration;
   private cluster = '1';
   private eventBus = new EventEmitter();
   private pollProcessor: PollingProcessor;
@@ -356,6 +363,7 @@ export default class Client {
       this.environment,
       this.cluster,
       this.api,
+      this.apiConfiguration,
       this.options,
       this.eventBus,
       this.repository,
@@ -367,6 +375,7 @@ export default class Client {
       this.streamProcessor = new StreamProcessor(
         this.api,
         this.sdkKey,
+        apiConfiguration,
         this.environment,
         this.authToken,
         this.options,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 import LRU from 'lru-cache';
 import { ConsoleLog } from './log';
 import { FileStore } from './store';
-import { Options } from './types';
+import { APIConfiguration, Options } from './types';
 
 export const ONE_HUNDRED = 100;
 
@@ -45,4 +45,9 @@ export const defaultOptions: Options = {
   store: new FileStore(),
   logger: new ConsoleLog(),
   axiosTimeout: 30000,
+};
+
+const TARGET_SEGMENT_RULES_QUERY_PARAMETER = 'v2';
+export const apiConfiguration: APIConfiguration = {
+  targetSegmentRulesQueryParameter: TARGET_SEGMENT_RULES_QUERY_PARAMETER,
 };

--- a/src/openapi/api.ts
+++ b/src/openapi/api.ts
@@ -22,63 +22,63 @@ import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObj
 import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from './base';
 
 /**
- * 
+ *
  * @export
  * @interface AuthenticationRequest
  */
 export interface AuthenticationRequest {
     /**
-     * 
+     *
      * @type {string}
      * @memberof AuthenticationRequest
      */
     apiKey: string;
     /**
-     * 
+     *
      * @type {AuthenticationRequestTarget}
      * @memberof AuthenticationRequest
      */
     target?: AuthenticationRequestTarget;
 }
 /**
- * 
+ *
  * @export
  * @interface AuthenticationRequestTarget
  */
 export interface AuthenticationRequestTarget {
     /**
-     * 
+     *
      * @type {string}
      * @memberof AuthenticationRequestTarget
      */
     identifier: string;
     /**
-     * 
+     *
      * @type {string}
      * @memberof AuthenticationRequestTarget
      */
     name?: string;
     /**
-     * 
+     *
      * @type {boolean}
      * @memberof AuthenticationRequestTarget
      */
     anonymous?: boolean;
     /**
-     * 
+     *
      * @type {object}
      * @memberof AuthenticationRequestTarget
      */
     attributes?: object;
 }
 /**
- * 
+ *
  * @export
  * @interface AuthenticationResponse
  */
 export interface AuthenticationResponse {
     /**
-     * 
+     *
      * @type {string}
      * @memberof AuthenticationResponse
      */
@@ -141,110 +141,110 @@ export interface Distribution {
     variations: Array<WeightedVariation>;
 }
 /**
- * 
+ *
  * @export
  * @interface Evaluation
  */
 export interface Evaluation {
     /**
-     * 
+     *
      * @type {string}
      * @memberof Evaluation
      */
     flag: string;
     /**
-     * 
+     *
      * @type {string}
      * @memberof Evaluation
      */
     value: string;
     /**
-     * 
+     *
      * @type {string}
      * @memberof Evaluation
      */
     kind: string;
     /**
-     * 
+     *
      * @type {string}
      * @memberof Evaluation
      */
     identifier?: string;
 }
 /**
- * 
+ *
  * @export
  * @interface FeatureConfig
  */
 export interface FeatureConfig {
     /**
-     * 
+     *
      * @type {string}
      * @memberof FeatureConfig
      */
     project: string;
     /**
-     * 
+     *
      * @type {string}
      * @memberof FeatureConfig
      */
     environment: string;
     /**
-     * 
+     *
      * @type {string}
      * @memberof FeatureConfig
      */
     feature: string;
     /**
-     * 
+     *
      * @type {FeatureState}
      * @memberof FeatureConfig
      */
     state: FeatureState;
     /**
-     * 
+     *
      * @type {string}
      * @memberof FeatureConfig
      */
     kind: FeatureConfigKindEnum;
     /**
-     * 
+     *
      * @type {Array<Variation>}
      * @memberof FeatureConfig
      */
     variations: Array<Variation>;
     /**
-     * 
+     *
      * @type {Array<ServingRule>}
      * @memberof FeatureConfig
      */
     rules?: Array<ServingRule>;
     /**
-     * 
+     *
      * @type {Serve}
      * @memberof FeatureConfig
      */
     defaultServe: Serve;
     /**
-     * 
+     *
      * @type {string}
      * @memberof FeatureConfig
      */
     offVariation: string;
     /**
-     * 
+     *
      * @type {Array<Prerequisite>}
      * @memberof FeatureConfig
      */
     prerequisites?: Array<Prerequisite>;
     /**
-     * 
+     *
      * @type {Array<VariationMap>}
      * @memberof FeatureConfig
      */
     variationToTargetMap?: Array<VariationMap>;
     /**
-     * 
+     *
      * @type {number}
      * @memberof FeatureConfig
      */
@@ -299,58 +299,58 @@ export interface GroupServingRule {
     clauses: Array<Clause>;
 }
 /**
- * 
+ *
  * @export
  * @interface InlineObject
  */
 export interface InlineObject {
     /**
-     * 
+     *
      * @type {string}
      * @memberof InlineObject
      */
     proxyKey: string;
 }
 /**
- * 
+ *
  * @export
  * @interface KeyValue
  */
 export interface KeyValue {
     /**
-     * 
+     *
      * @type {string}
      * @memberof KeyValue
      */
     key: string;
     /**
-     * 
+     *
      * @type {string}
      * @memberof KeyValue
      */
     value: string;
 }
 /**
- * 
+ *
  * @export
  * @interface Metrics
  */
 export interface Metrics {
     /**
-     * 
+     *
      * @type {Array<TargetData>}
      * @memberof Metrics
      */
     targetData?: Array<TargetData>;
     /**
-     * 
+     *
      * @type {Array<MetricsData>}
      * @memberof Metrics
      */
     metricsData?: Array<MetricsData>;
 }
 /**
- * 
+ *
  * @export
  * @interface MetricsData
  */
@@ -362,7 +362,7 @@ export interface MetricsData {
      */
     timestamp: number;
     /**
-     * 
+     *
      * @type {number}
      * @memberof MetricsData
      */
@@ -374,7 +374,7 @@ export interface MetricsData {
      */
     metricsType: MetricsDataMetricsTypeEnum;
     /**
-     * 
+     *
      * @type {Array<KeyValue>}
      * @memberof MetricsData
      */
@@ -390,7 +390,7 @@ export enum MetricsDataMetricsTypeEnum {
 }
 
 /**
- * 
+ *
  * @export
  * @interface ModelError
  */
@@ -415,7 +415,7 @@ export interface ModelError {
     details?: object;
 }
 /**
- * 
+ *
  * @export
  * @interface Pagination
  */
@@ -507,51 +507,51 @@ export interface ProxyConfig {
      */
     pageIndex: number;
     /**
-     * 
+     *
      * @type {Array<ProxyConfigAllOfEnvironments>}
      * @memberof ProxyConfig
      */
     environments?: Array<ProxyConfigAllOfEnvironments>;
 }
 /**
- * 
+ *
  * @export
  * @interface ProxyConfigAllOf
  */
 export interface ProxyConfigAllOf {
     /**
-     * 
+     *
      * @type {Array<ProxyConfigAllOfEnvironments>}
      * @memberof ProxyConfigAllOf
      */
     environments?: Array<ProxyConfigAllOfEnvironments>;
 }
 /**
- * 
+ *
  * @export
  * @interface ProxyConfigAllOfEnvironments
  */
 export interface ProxyConfigAllOfEnvironments {
     /**
-     * 
+     *
      * @type {string}
      * @memberof ProxyConfigAllOfEnvironments
      */
     id?: string;
     /**
-     * 
+     *
      * @type {Array<string>}
      * @memberof ProxyConfigAllOfEnvironments
      */
     apiKeys?: Array<string>;
     /**
-     * 
+     *
      * @type {Array<FeatureConfig>}
      * @memberof ProxyConfigAllOfEnvironments
      */
     featureConfigs?: Array<FeatureConfig>;
     /**
-     * 
+     *
      * @type {Array<Segment>}
      * @memberof ProxyConfigAllOfEnvironments
      */
@@ -600,7 +600,7 @@ export interface Segment {
      */
     excluded?: Array<Target>;
     /**
-     * 
+     *
      * @type {Array<Clause>}
      * @memberof Segment
      */
@@ -637,13 +637,13 @@ export interface Segment {
  */
 export interface Serve {
     /**
-     * 
+     *
      * @type {Distribution}
      * @memberof Serve
      */
     distribution?: Distribution;
     /**
-     * 
+     *
      * @type {string}
      * @memberof Serve
      */
@@ -674,7 +674,7 @@ export interface ServingRule {
      */
     clauses: Array<Clause>;
     /**
-     * 
+     *
      * @type {Serve}
      * @memberof ServingRule
      */
@@ -767,25 +767,25 @@ export interface Target {
     segments?: Array<Segment>;
 }
 /**
- * 
+ *
  * @export
  * @interface TargetData
  */
 export interface TargetData {
     /**
-     * 
+     *
      * @type {string}
      * @memberof TargetData
      */
     identifier: string;
     /**
-     * 
+     *
      * @type {string}
      * @memberof TargetData
      */
     name: string;
     /**
-     * 
+     *
      * @type {Array<KeyValue>}
      * @memberof TargetData
      */
@@ -895,7 +895,7 @@ export const ClientApiAxiosParamCreator = function (configuration?: Configuratio
         /**
          * Used to retrieve all target segments for certain account id.
          * @summary Authenticate with the admin server.
-         * @param {AuthenticationRequest} [authenticationRequest] 
+         * @param {AuthenticationRequest} [authenticationRequest]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -913,7 +913,7 @@ export const ClientApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarQueryParameter = {} as any;
 
 
-    
+
             localVarHeaderParameter['Content-Type'] = 'application/json';
 
             setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
@@ -964,7 +964,7 @@ export const ClientApiAxiosParamCreator = function (configuration?: Configuratio
             }
 
 
-    
+
             setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
@@ -975,7 +975,7 @@ export const ClientApiAxiosParamCreator = function (configuration?: Configuratio
             };
         },
         /**
-         * 
+         *
          * @summary Get feature evaluations for target
          * @param {string} environmentUUID Unique identifier for the environment object in the API.
          * @param {string} feature Unique identifier for the flag object in the API.
@@ -1015,7 +1015,7 @@ export const ClientApiAxiosParamCreator = function (configuration?: Configuratio
             }
 
 
-    
+
             setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
@@ -1026,7 +1026,7 @@ export const ClientApiAxiosParamCreator = function (configuration?: Configuratio
             };
         },
         /**
-         * 
+         *
          * @summary Get feature evaluations for target
          * @param {string} environmentUUID Unique identifier for the environment object in the API.
          * @param {string} target Unique identifier for the target object in the API.
@@ -1062,7 +1062,7 @@ export const ClientApiAxiosParamCreator = function (configuration?: Configuratio
             }
 
 
-    
+
             setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
@@ -1105,7 +1105,7 @@ export const ClientApiAxiosParamCreator = function (configuration?: Configuratio
             }
 
 
-    
+
             setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
@@ -1116,7 +1116,7 @@ export const ClientApiAxiosParamCreator = function (configuration?: Configuratio
             };
         },
         /**
-         * 
+         *
          * @summary Get feature config
          * @param {string} identifier Unique identifier for the flag object in the API.
          * @param {string} environmentUUID Unique identifier for the environment object in the API.
@@ -1152,7 +1152,7 @@ export const ClientApiAxiosParamCreator = function (configuration?: Configuratio
             }
 
 
-    
+
             setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
@@ -1204,7 +1204,7 @@ export const ClientApiAxiosParamCreator = function (configuration?: Configuratio
             }
 
 
-    
+
             setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
@@ -1215,9 +1215,9 @@ export const ClientApiAxiosParamCreator = function (configuration?: Configuratio
             };
         },
         /**
-         * 
+         *
          * @summary Stream endpoint.
-         * @param {string} aPIKey 
+         * @param {string} aPIKey
          * @param {string} [cluster] Unique identifier for the cluster for the account
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -1250,7 +1250,7 @@ export const ClientApiAxiosParamCreator = function (configuration?: Configuratio
             }
 
 
-    
+
             setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
@@ -1273,7 +1273,7 @@ export const ClientApiFp = function(configuration?: Configuration) {
         /**
          * Used to retrieve all target segments for certain account id.
          * @summary Authenticate with the admin server.
-         * @param {AuthenticationRequest} [authenticationRequest] 
+         * @param {AuthenticationRequest} [authenticationRequest]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -1295,7 +1295,7 @@ export const ClientApiFp = function(configuration?: Configuration) {
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
-         * 
+         *
          * @summary Get feature evaluations for target
          * @param {string} environmentUUID Unique identifier for the environment object in the API.
          * @param {string} feature Unique identifier for the flag object in the API.
@@ -1309,7 +1309,7 @@ export const ClientApiFp = function(configuration?: Configuration) {
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
-         * 
+         *
          * @summary Get feature evaluations for target
          * @param {string} environmentUUID Unique identifier for the environment object in the API.
          * @param {string} target Unique identifier for the target object in the API.
@@ -1317,7 +1317,7 @@ export const ClientApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getEvaluations(environmentUUID: string, target: string, cluster?: string, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pagination & Array>> {
+        async getEvaluations(environmentUUID: string, target: string, cluster?: string, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pagination & Array<object>>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.getEvaluations(environmentUUID, target, cluster, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
@@ -1334,7 +1334,7 @@ export const ClientApiFp = function(configuration?: Configuration) {
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
-         * 
+         *
          * @summary Get feature config
          * @param {string} identifier Unique identifier for the flag object in the API.
          * @param {string} environmentUUID Unique identifier for the environment object in the API.
@@ -1361,9 +1361,9 @@ export const ClientApiFp = function(configuration?: Configuration) {
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
-         * 
+         *
          * @summary Stream endpoint.
-         * @param {string} aPIKey 
+         * @param {string} aPIKey
          * @param {string} [cluster] Unique identifier for the cluster for the account
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -1385,7 +1385,7 @@ export const ClientApiFactory = function (configuration?: Configuration, basePat
         /**
          * Used to retrieve all target segments for certain account id.
          * @summary Authenticate with the admin server.
-         * @param {AuthenticationRequest} [authenticationRequest] 
+         * @param {AuthenticationRequest} [authenticationRequest]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -1405,7 +1405,7 @@ export const ClientApiFactory = function (configuration?: Configuration, basePat
             return localVarFp.getAllSegments(environmentUUID, cluster, rules, options).then((request) => request(axios, basePath));
         },
         /**
-         * 
+         *
          * @summary Get feature evaluations for target
          * @param {string} environmentUUID Unique identifier for the environment object in the API.
          * @param {string} feature Unique identifier for the flag object in the API.
@@ -1418,7 +1418,7 @@ export const ClientApiFactory = function (configuration?: Configuration, basePat
             return localVarFp.getEvaluationByIdentifier(environmentUUID, feature, target, cluster, options).then((request) => request(axios, basePath));
         },
         /**
-         * 
+         *
          * @summary Get feature evaluations for target
          * @param {string} environmentUUID Unique identifier for the environment object in the API.
          * @param {string} target Unique identifier for the target object in the API.
@@ -1426,7 +1426,7 @@ export const ClientApiFactory = function (configuration?: Configuration, basePat
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEvaluations(environmentUUID: string, target: string, cluster?: string, options?: any): AxiosPromise<Pagination & Array> {
+        getEvaluations(environmentUUID: string, target: string, cluster?: string, options?: any): AxiosPromise<Pagination & Array<object>> {
             return localVarFp.getEvaluations(environmentUUID, target, cluster, options).then((request) => request(axios, basePath));
         },
         /**
@@ -1441,7 +1441,7 @@ export const ClientApiFactory = function (configuration?: Configuration, basePat
             return localVarFp.getFeatureConfig(environmentUUID, cluster, options).then((request) => request(axios, basePath));
         },
         /**
-         * 
+         *
          * @summary Get feature config
          * @param {string} identifier Unique identifier for the flag object in the API.
          * @param {string} environmentUUID Unique identifier for the environment object in the API.
@@ -1466,9 +1466,9 @@ export const ClientApiFactory = function (configuration?: Configuration, basePat
             return localVarFp.getSegmentByIdentifier(identifier, environmentUUID, cluster, rules, options).then((request) => request(axios, basePath));
         },
         /**
-         * 
+         *
          * @summary Stream endpoint.
-         * @param {string} aPIKey 
+         * @param {string} aPIKey
          * @param {string} [cluster] Unique identifier for the cluster for the account
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -1489,7 +1489,7 @@ export class ClientApi extends BaseAPI {
     /**
      * Used to retrieve all target segments for certain account id.
      * @summary Authenticate with the admin server.
-     * @param {AuthenticationRequest} [authenticationRequest] 
+     * @param {AuthenticationRequest} [authenticationRequest]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ClientApi
@@ -1513,7 +1513,7 @@ export class ClientApi extends BaseAPI {
     }
 
     /**
-     * 
+     *
      * @summary Get feature evaluations for target
      * @param {string} environmentUUID Unique identifier for the environment object in the API.
      * @param {string} feature Unique identifier for the flag object in the API.
@@ -1528,7 +1528,7 @@ export class ClientApi extends BaseAPI {
     }
 
     /**
-     * 
+     *
      * @summary Get feature evaluations for target
      * @param {string} environmentUUID Unique identifier for the environment object in the API.
      * @param {string} target Unique identifier for the target object in the API.
@@ -1555,7 +1555,7 @@ export class ClientApi extends BaseAPI {
     }
 
     /**
-     * 
+     *
      * @summary Get feature config
      * @param {string} identifier Unique identifier for the flag object in the API.
      * @param {string} environmentUUID Unique identifier for the environment object in the API.
@@ -1584,9 +1584,9 @@ export class ClientApi extends BaseAPI {
     }
 
     /**
-     * 
+     *
      * @summary Stream endpoint.
-     * @param {string} aPIKey 
+     * @param {string} aPIKey
      * @param {string} [cluster] Unique identifier for the cluster for the account
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -1609,7 +1609,7 @@ export const MetricsApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Send metrics to the Analytics server.
          * @param {string} environmentUUID environment parameter in query.
          * @param {string} [cluster] Unique identifier for the cluster for the account
-         * @param {Metrics} [metrics] 
+         * @param {Metrics} [metrics]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -1641,7 +1641,7 @@ export const MetricsApiAxiosParamCreator = function (configuration?: Configurati
             }
 
 
-    
+
             localVarHeaderParameter['Content-Type'] = 'application/json';
 
             setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
@@ -1669,7 +1669,7 @@ export const MetricsApiFp = function(configuration?: Configuration) {
          * @summary Send metrics to the Analytics server.
          * @param {string} environmentUUID environment parameter in query.
          * @param {string} [cluster] Unique identifier for the cluster for the account
-         * @param {Metrics} [metrics] 
+         * @param {Metrics} [metrics]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -1692,7 +1692,7 @@ export const MetricsApiFactory = function (configuration?: Configuration, basePa
          * @summary Send metrics to the Analytics server.
          * @param {string} environmentUUID environment parameter in query.
          * @param {string} [cluster] Unique identifier for the cluster for the account
-         * @param {Metrics} [metrics] 
+         * @param {Metrics} [metrics]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -1714,7 +1714,7 @@ export class MetricsApi extends BaseAPI {
      * @summary Send metrics to the Analytics server.
      * @param {string} environmentUUID environment parameter in query.
      * @param {string} [cluster] Unique identifier for the cluster for the account
-     * @param {Metrics} [metrics] 
+     * @param {Metrics} [metrics]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof MetricsApi
@@ -1734,7 +1734,7 @@ export const ProxyApiAxiosParamCreator = function (configuration?: Configuration
         /**
          * Endpoint that the Proxy can use to authenticate with the client server
          * @summary Endpoint that the Proxy can use to authenticate with the client server
-         * @param {InlineObject} [inlineObject] 
+         * @param {InlineObject} [inlineObject]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -1752,7 +1752,7 @@ export const ProxyApiAxiosParamCreator = function (configuration?: Configuration
             const localVarQueryParameter = {} as any;
 
 
-    
+
             localVarHeaderParameter['Content-Type'] = 'application/json';
 
             setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
@@ -1816,7 +1816,7 @@ export const ProxyApiAxiosParamCreator = function (configuration?: Configuration
             }
 
 
-    
+
             setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
@@ -1839,7 +1839,7 @@ export const ProxyApiFp = function(configuration?: Configuration) {
         /**
          * Endpoint that the Proxy can use to authenticate with the client server
          * @summary Endpoint that the Proxy can use to authenticate with the client server
-         * @param {InlineObject} [inlineObject] 
+         * @param {InlineObject} [inlineObject]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -1875,7 +1875,7 @@ export const ProxyApiFactory = function (configuration?: Configuration, basePath
         /**
          * Endpoint that the Proxy can use to authenticate with the client server
          * @summary Endpoint that the Proxy can use to authenticate with the client server
-         * @param {InlineObject} [inlineObject] 
+         * @param {InlineObject} [inlineObject]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -1909,7 +1909,7 @@ export class ProxyApi extends BaseAPI {
     /**
      * Endpoint that the Proxy can use to authenticate with the client server
      * @summary Endpoint that the Proxy can use to authenticate with the client server
-     * @param {InlineObject} [inlineObject] 
+     * @param {InlineObject} [inlineObject]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ProxyApi

--- a/src/openapi/api.ts
+++ b/src/openapi/api.ts
@@ -301,6 +301,19 @@ export interface GroupServingRule {
 /**
  * 
  * @export
+ * @interface InlineObject
+ */
+export interface InlineObject {
+    /**
+     * 
+     * @type {string}
+     * @memberof InlineObject
+     */
+    proxyKey: string;
+}
+/**
+ * 
+ * @export
  * @interface KeyValue
  */
 export interface KeyValue {
@@ -456,6 +469,93 @@ export interface Prerequisite {
      * @memberof Prerequisite
      */
     variations: Array<string>;
+}
+/**
+ * TBD
+ * @export
+ * @interface ProxyConfig
+ */
+export interface ProxyConfig {
+    /**
+     * The version of this object.  The version will be incremented each time the object is modified
+     * @type {number}
+     * @memberof ProxyConfig
+     */
+    version?: number;
+    /**
+     * The total number of pages
+     * @type {number}
+     * @memberof ProxyConfig
+     */
+    pageCount: number;
+    /**
+     * The total number of items
+     * @type {number}
+     * @memberof ProxyConfig
+     */
+    itemCount: number;
+    /**
+     * The number of items per page
+     * @type {number}
+     * @memberof ProxyConfig
+     */
+    pageSize: number;
+    /**
+     * The current page
+     * @type {number}
+     * @memberof ProxyConfig
+     */
+    pageIndex: number;
+    /**
+     * 
+     * @type {Array<ProxyConfigAllOfEnvironments>}
+     * @memberof ProxyConfig
+     */
+    environments?: Array<ProxyConfigAllOfEnvironments>;
+}
+/**
+ * 
+ * @export
+ * @interface ProxyConfigAllOf
+ */
+export interface ProxyConfigAllOf {
+    /**
+     * 
+     * @type {Array<ProxyConfigAllOfEnvironments>}
+     * @memberof ProxyConfigAllOf
+     */
+    environments?: Array<ProxyConfigAllOfEnvironments>;
+}
+/**
+ * 
+ * @export
+ * @interface ProxyConfigAllOfEnvironments
+ */
+export interface ProxyConfigAllOfEnvironments {
+    /**
+     * 
+     * @type {string}
+     * @memberof ProxyConfigAllOfEnvironments
+     */
+    id?: string;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof ProxyConfigAllOfEnvironments
+     */
+    apiKeys?: Array<string>;
+    /**
+     * 
+     * @type {Array<FeatureConfig>}
+     * @memberof ProxyConfigAllOfEnvironments
+     */
+    featureConfigs?: Array<FeatureConfig>;
+    /**
+     * 
+     * @type {Array<Segment>}
+     * @memberof ProxyConfigAllOfEnvironments
+     */
+    segments?: Array<Segment>;
 }
 /**
  * A Target Group (Segment) response
@@ -831,10 +931,11 @@ export const ClientApiAxiosParamCreator = function (configuration?: Configuratio
          * @summary Retrieve all segments.
          * @param {string} environmentUUID Unique identifier for the environment object in the API.
          * @param {string} [cluster] Unique identifier for the cluster for the account
+         * @param {string} [rules] When set to rules&#x3D;v2 will return AND rule compatible serving_rules field. When not set or set to any other value will return old rules field only compatible with OR rules.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getAllSegments: async (environmentUUID: string, cluster?: string, options: any = {}): Promise<RequestArgs> => {
+        getAllSegments: async (environmentUUID: string, cluster?: string, rules?: string, options: any = {}): Promise<RequestArgs> => {
             // verify required parameter 'environmentUUID' is not null or undefined
             assertParamExists('getAllSegments', 'environmentUUID', environmentUUID)
             const localVarPath = `/client/env/{environmentUUID}/target-segments`
@@ -856,6 +957,10 @@ export const ClientApiAxiosParamCreator = function (configuration?: Configuratio
 
             if (cluster !== undefined) {
                 localVarQueryParameter['cluster'] = cluster;
+            }
+
+            if (rules !== undefined) {
+                localVarQueryParameter['rules'] = rules;
             }
 
 
@@ -1063,10 +1168,11 @@ export const ClientApiAxiosParamCreator = function (configuration?: Configuratio
          * @param {string} identifier Unique identifier for the segment object in the API
          * @param {string} environmentUUID Unique identifier for the environment object in the API
          * @param {string} [cluster] Unique identifier for the cluster for the account
+         * @param {string} [rules] When set to rules&#x3D;v2 will return AND rule compatible serving_rules field. When not set or set to any other value will return old rules field only compatible with OR rules.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getSegmentByIdentifier: async (identifier: string, environmentUUID: string, cluster?: string, options: any = {}): Promise<RequestArgs> => {
+        getSegmentByIdentifier: async (identifier: string, environmentUUID: string, cluster?: string, rules?: string, options: any = {}): Promise<RequestArgs> => {
             // verify required parameter 'identifier' is not null or undefined
             assertParamExists('getSegmentByIdentifier', 'identifier', identifier)
             // verify required parameter 'environmentUUID' is not null or undefined
@@ -1091,6 +1197,10 @@ export const ClientApiAxiosParamCreator = function (configuration?: Configuratio
 
             if (cluster !== undefined) {
                 localVarQueryParameter['cluster'] = cluster;
+            }
+
+            if (rules !== undefined) {
+                localVarQueryParameter['rules'] = rules;
             }
 
 
@@ -1176,11 +1286,12 @@ export const ClientApiFp = function(configuration?: Configuration) {
          * @summary Retrieve all segments.
          * @param {string} environmentUUID Unique identifier for the environment object in the API.
          * @param {string} [cluster] Unique identifier for the cluster for the account
+         * @param {string} [rules] When set to rules&#x3D;v2 will return AND rule compatible serving_rules field. When not set or set to any other value will return old rules field only compatible with OR rules.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getAllSegments(environmentUUID: string, cluster?: string, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Segment>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getAllSegments(environmentUUID, cluster, options);
+        async getAllSegments(environmentUUID: string, cluster?: string, rules?: string, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Segment>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getAllSegments(environmentUUID, cluster, rules, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1206,7 +1317,7 @@ export const ClientApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getEvaluations(environmentUUID: string, target: string, cluster?: string, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pagination & object>> {
+        async getEvaluations(environmentUUID: string, target: string, cluster?: string, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pagination & Array>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.getEvaluations(environmentUUID, target, cluster, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
@@ -1241,11 +1352,12 @@ export const ClientApiFp = function(configuration?: Configuration) {
          * @param {string} identifier Unique identifier for the segment object in the API
          * @param {string} environmentUUID Unique identifier for the environment object in the API
          * @param {string} [cluster] Unique identifier for the cluster for the account
+         * @param {string} [rules] When set to rules&#x3D;v2 will return AND rule compatible serving_rules field. When not set or set to any other value will return old rules field only compatible with OR rules.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getSegmentByIdentifier(identifier: string, environmentUUID: string, cluster?: string, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Segment>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getSegmentByIdentifier(identifier, environmentUUID, cluster, options);
+        async getSegmentByIdentifier(identifier: string, environmentUUID: string, cluster?: string, rules?: string, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Segment>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getSegmentByIdentifier(identifier, environmentUUID, cluster, rules, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1285,11 +1397,12 @@ export const ClientApiFactory = function (configuration?: Configuration, basePat
          * @summary Retrieve all segments.
          * @param {string} environmentUUID Unique identifier for the environment object in the API.
          * @param {string} [cluster] Unique identifier for the cluster for the account
+         * @param {string} [rules] When set to rules&#x3D;v2 will return AND rule compatible serving_rules field. When not set or set to any other value will return old rules field only compatible with OR rules.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getAllSegments(environmentUUID: string, cluster?: string, options?: any): AxiosPromise<Array<Segment>> {
-            return localVarFp.getAllSegments(environmentUUID, cluster, options).then((request) => request(axios, basePath));
+        getAllSegments(environmentUUID: string, cluster?: string, rules?: string, options?: any): AxiosPromise<Array<Segment>> {
+            return localVarFp.getAllSegments(environmentUUID, cluster, rules, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -1313,7 +1426,7 @@ export const ClientApiFactory = function (configuration?: Configuration, basePat
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEvaluations(environmentUUID: string, target: string, cluster?: string, options?: any): AxiosPromise<Pagination & object> {
+        getEvaluations(environmentUUID: string, target: string, cluster?: string, options?: any): AxiosPromise<Pagination & Array> {
             return localVarFp.getEvaluations(environmentUUID, target, cluster, options).then((request) => request(axios, basePath));
         },
         /**
@@ -1345,11 +1458,12 @@ export const ClientApiFactory = function (configuration?: Configuration, basePat
          * @param {string} identifier Unique identifier for the segment object in the API
          * @param {string} environmentUUID Unique identifier for the environment object in the API
          * @param {string} [cluster] Unique identifier for the cluster for the account
+         * @param {string} [rules] When set to rules&#x3D;v2 will return AND rule compatible serving_rules field. When not set or set to any other value will return old rules field only compatible with OR rules.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getSegmentByIdentifier(identifier: string, environmentUUID: string, cluster?: string, options?: any): AxiosPromise<Segment> {
-            return localVarFp.getSegmentByIdentifier(identifier, environmentUUID, cluster, options).then((request) => request(axios, basePath));
+        getSegmentByIdentifier(identifier: string, environmentUUID: string, cluster?: string, rules?: string, options?: any): AxiosPromise<Segment> {
+            return localVarFp.getSegmentByIdentifier(identifier, environmentUUID, cluster, rules, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -1389,12 +1503,13 @@ export class ClientApi extends BaseAPI {
      * @summary Retrieve all segments.
      * @param {string} environmentUUID Unique identifier for the environment object in the API.
      * @param {string} [cluster] Unique identifier for the cluster for the account
+     * @param {string} [rules] When set to rules&#x3D;v2 will return AND rule compatible serving_rules field. When not set or set to any other value will return old rules field only compatible with OR rules.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ClientApi
      */
-    public getAllSegments(environmentUUID: string, cluster?: string, options?: any) {
-        return ClientApiFp(this.configuration).getAllSegments(environmentUUID, cluster, options).then((request) => request(this.axios, this.basePath));
+    public getAllSegments(environmentUUID: string, cluster?: string, rules?: string, options?: any) {
+        return ClientApiFp(this.configuration).getAllSegments(environmentUUID, cluster, rules, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -1459,12 +1574,13 @@ export class ClientApi extends BaseAPI {
      * @param {string} identifier Unique identifier for the segment object in the API
      * @param {string} environmentUUID Unique identifier for the environment object in the API
      * @param {string} [cluster] Unique identifier for the cluster for the account
+     * @param {string} [rules] When set to rules&#x3D;v2 will return AND rule compatible serving_rules field. When not set or set to any other value will return old rules field only compatible with OR rules.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ClientApi
      */
-    public getSegmentByIdentifier(identifier: string, environmentUUID: string, cluster?: string, options?: any) {
-        return ClientApiFp(this.configuration).getSegmentByIdentifier(identifier, environmentUUID, cluster, options).then((request) => request(this.axios, this.basePath));
+    public getSegmentByIdentifier(identifier: string, environmentUUID: string, cluster?: string, rules?: string, options?: any) {
+        return ClientApiFp(this.configuration).getSegmentByIdentifier(identifier, environmentUUID, cluster, rules, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -1605,6 +1721,217 @@ export class MetricsApi extends BaseAPI {
      */
     public postMetrics(environmentUUID: string, cluster?: string, metrics?: Metrics, options?: any) {
         return MetricsApiFp(this.configuration).postMetrics(environmentUUID, cluster, metrics, options).then((request) => request(this.axios, this.basePath));
+    }
+}
+
+
+/**
+ * ProxyApi - axios parameter creator
+ * @export
+ */
+export const ProxyApiAxiosParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * Endpoint that the Proxy can use to authenticate with the client server
+         * @summary Endpoint that the Proxy can use to authenticate with the client server
+         * @param {InlineObject} [inlineObject] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        authenticateProxyKey: async (inlineObject?: InlineObject, options: any = {}): Promise<RequestArgs> => {
+            const localVarPath = `/proxy/auth`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(inlineObject, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Gets Proxy config for multiple environments if the Key query param is provided or gets config for a single environment if an environment query param is provided
+         * @summary Gets Proxy config for multiple environments
+         * @param {string} key Accpets a Proxy Key.
+         * @param {number} [pageNumber] PageNumber
+         * @param {number} [pageSize] PageSize
+         * @param {string} [cluster] Unique identifier for the cluster for the account
+         * @param {string} [environment] Accepts an EnvironmentID. If this is provided then the endpoint will only return config for this environment. If this is left empty then the Proxy will return config for all environments associated with the Proxy Key.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getProxyConfig: async (key: string, pageNumber?: number, pageSize?: number, cluster?: string, environment?: string, options: any = {}): Promise<RequestArgs> => {
+            // verify required parameter 'key' is not null or undefined
+            assertParamExists('getProxyConfig', 'key', key)
+            const localVarPath = `/proxy/config`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            if (pageNumber !== undefined) {
+                localVarQueryParameter['pageNumber'] = pageNumber;
+            }
+
+            if (pageSize !== undefined) {
+                localVarQueryParameter['pageSize'] = pageSize;
+            }
+
+            if (cluster !== undefined) {
+                localVarQueryParameter['cluster'] = cluster;
+            }
+
+            if (environment !== undefined) {
+                localVarQueryParameter['environment'] = environment;
+            }
+
+            if (key !== undefined) {
+                localVarQueryParameter['key'] = key;
+            }
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    }
+};
+
+/**
+ * ProxyApi - functional programming interface
+ * @export
+ */
+export const ProxyApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = ProxyApiAxiosParamCreator(configuration)
+    return {
+        /**
+         * Endpoint that the Proxy can use to authenticate with the client server
+         * @summary Endpoint that the Proxy can use to authenticate with the client server
+         * @param {InlineObject} [inlineObject] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async authenticateProxyKey(inlineObject?: InlineObject, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AuthenticationResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.authenticateProxyKey(inlineObject, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * Gets Proxy config for multiple environments if the Key query param is provided or gets config for a single environment if an environment query param is provided
+         * @summary Gets Proxy config for multiple environments
+         * @param {string} key Accpets a Proxy Key.
+         * @param {number} [pageNumber] PageNumber
+         * @param {number} [pageSize] PageSize
+         * @param {string} [cluster] Unique identifier for the cluster for the account
+         * @param {string} [environment] Accepts an EnvironmentID. If this is provided then the endpoint will only return config for this environment. If this is left empty then the Proxy will return config for all environments associated with the Proxy Key.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getProxyConfig(key: string, pageNumber?: number, pageSize?: number, cluster?: string, environment?: string, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ProxyConfig>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getProxyConfig(key, pageNumber, pageSize, cluster, environment, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+    }
+};
+
+/**
+ * ProxyApi - factory interface
+ * @export
+ */
+export const ProxyApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = ProxyApiFp(configuration)
+    return {
+        /**
+         * Endpoint that the Proxy can use to authenticate with the client server
+         * @summary Endpoint that the Proxy can use to authenticate with the client server
+         * @param {InlineObject} [inlineObject] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        authenticateProxyKey(inlineObject?: InlineObject, options?: any): AxiosPromise<AuthenticationResponse> {
+            return localVarFp.authenticateProxyKey(inlineObject, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Gets Proxy config for multiple environments if the Key query param is provided or gets config for a single environment if an environment query param is provided
+         * @summary Gets Proxy config for multiple environments
+         * @param {string} key Accpets a Proxy Key.
+         * @param {number} [pageNumber] PageNumber
+         * @param {number} [pageSize] PageSize
+         * @param {string} [cluster] Unique identifier for the cluster for the account
+         * @param {string} [environment] Accepts an EnvironmentID. If this is provided then the endpoint will only return config for this environment. If this is left empty then the Proxy will return config for all environments associated with the Proxy Key.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getProxyConfig(key: string, pageNumber?: number, pageSize?: number, cluster?: string, environment?: string, options?: any): AxiosPromise<ProxyConfig> {
+            return localVarFp.getProxyConfig(key, pageNumber, pageSize, cluster, environment, options).then((request) => request(axios, basePath));
+        },
+    };
+};
+
+/**
+ * ProxyApi - object-oriented interface
+ * @export
+ * @class ProxyApi
+ * @extends {BaseAPI}
+ */
+export class ProxyApi extends BaseAPI {
+    /**
+     * Endpoint that the Proxy can use to authenticate with the client server
+     * @summary Endpoint that the Proxy can use to authenticate with the client server
+     * @param {InlineObject} [inlineObject] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ProxyApi
+     */
+    public authenticateProxyKey(inlineObject?: InlineObject, options?: any) {
+        return ProxyApiFp(this.configuration).authenticateProxyKey(inlineObject, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Gets Proxy config for multiple environments if the Key query param is provided or gets config for a single environment if an environment query param is provided
+     * @summary Gets Proxy config for multiple environments
+     * @param {string} key Accpets a Proxy Key.
+     * @param {number} [pageNumber] PageNumber
+     * @param {number} [pageSize] PageSize
+     * @param {string} [cluster] Unique identifier for the cluster for the account
+     * @param {string} [environment] Accepts an EnvironmentID. If this is provided then the endpoint will only return config for this environment. If this is left empty then the Proxy will return config for all environments associated with the Proxy Key.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ProxyApi
+     */
+    public getProxyConfig(key: string, pageNumber?: number, pageSize?: number, cluster?: string, environment?: string, options?: any) {
+        return ProxyApiFp(this.configuration).getProxyConfig(key, pageNumber, pageSize, cluster, environment, options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/src/polling.ts
+++ b/src/polling.ts
@@ -1,5 +1,5 @@
 import { ClientApi, FeatureConfig, Segment } from './openapi';
-import { Options } from './types';
+import { APIConfiguration, Options } from './types';
 import EventEmitter from 'events';
 import { Repository } from './repository';
 import { ConsoleLog } from './log';
@@ -14,6 +14,7 @@ export class PollingProcessor {
   private environment: string;
   private cluster: string;
   private api: ClientApi;
+  private apiConfiguration: APIConfiguration;
   private stopped = true;
   private options: Options;
   private repository: Repository;
@@ -27,11 +28,13 @@ export class PollingProcessor {
     environment: string,
     cluster: string,
     api: ClientApi,
+    apiConfiguration: APIConfiguration,
     options: Options,
     eventBus: EventEmitter,
     repository: Repository,
   ) {
     this.api = api;
+    this.apiConfiguration = apiConfiguration;
     this.options = options;
     this.environment = environment;
     this.cluster = cluster;
@@ -113,6 +116,7 @@ export class PollingProcessor {
       const response = await this.api.getAllSegments(
         this.environment,
         this.cluster,
+        this.apiConfiguration.targetSegmentRulesQueryParameter,
       );
       this.log.debug('Fetching segments finished');
       // prepare cache for storing segments

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -18,6 +18,7 @@ type FetchFunction = (
   identifier: string,
   environment: string,
   cluster: string,
+  // Only target-segment requests require this, and it will be safely ignored for feature calls.
   targetSegmentRulesQueryParameter: string,
 ) => AxiosPromise<FeatureConfig | Segment>;
 

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 import { AxiosPromise } from 'axios';
 import { ClientApi, FeatureConfig, Segment } from './openapi';
-import { StreamEvent, Options, StreamMsg, APIConfiguration } from "./types";
+import { StreamEvent, Options, StreamMsg, APIConfiguration } from './types';
 import { Repository } from './repository';
 import { ConsoleLog } from './log';
 
@@ -18,8 +18,7 @@ type FetchFunction = (
   identifier: string,
   environment: string,
   cluster: string,
-  targetSegmentRulesQueryParameter: string
-
+  targetSegmentRulesQueryParameter: string,
 ) => AxiosPromise<FeatureConfig | Segment>;
 
 export class StreamProcessor {

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 import { AxiosPromise } from 'axios';
 import { ClientApi, FeatureConfig, Segment } from './openapi';
-import { StreamEvent, Options, StreamMsg } from './types';
+import { StreamEvent, Options, StreamMsg, APIConfiguration } from "./types";
 import { Repository } from './repository';
 import { ConsoleLog } from './log';
 
@@ -18,6 +18,8 @@ type FetchFunction = (
   identifier: string,
   environment: string,
   cluster: string,
+  targetSegmentRulesQueryParameter: string
+
 ) => AxiosPromise<FeatureConfig | Segment>;
 
 export class StreamProcessor {
@@ -31,6 +33,7 @@ export class StreamProcessor {
   private readonly environment: string;
   private readonly cluster: string;
   private readonly api: ClientApi;
+  private readonly apiConfiguration: APIConfiguration;
   private readonly repository: Repository;
   private readonly retryDelayMs: number;
   private readonly headers: Record<string, string>;
@@ -46,6 +49,7 @@ export class StreamProcessor {
   constructor(
     api: ClientApi,
     apiKey: string,
+    apiConfiguration: APIConfiguration,
     environment: string,
     jwtToken: string,
     options: Options,
@@ -57,6 +61,7 @@ export class StreamProcessor {
   ) {
     this.api = api;
     this.apiKey = apiKey;
+    this.apiConfiguration = apiConfiguration;
     this.environment = environment;
     this.jwtToken = jwtToken;
     this.options = options;
@@ -221,6 +226,7 @@ export class StreamProcessor {
           msg.identifier,
           this.environment,
           this.cluster,
+          this.apiConfiguration.targetSegmentRulesQueryParameter,
         );
         setFn(msg.identifier, data);
       } else if (msg.event === 'delete') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,10 @@ export interface Options {
   axiosTimeout?: number;
 }
 
+export interface APIConfiguration {
+  targetSegmentRulesQueryParameter: string;
+}
+
 export interface Claims {
   environment: string;
   environmentIdentifier: string;


### PR DESCRIPTION
# What
- Re-generates the API client to bring in the new target-segments query parameter rules
- Sets this parameter on the for requests to to `target-segments` (polling) and  `target-segments/{segment}` (streamed group changes)

# Testing

Manual inspection of final URL string when
- Pulling all segments
![Screenshot 2024-05-02 at 20 05 21](https://github.com/harness/ff-nodejs-server-sdk/assets/23323369/c5184296-d051-4e32-a460-6ffd58531de3)

- Pulling a specific segment when a group change has been streamed
![Screenshot 2024-05-02 at 20 04 51](https://github.com/harness/ff-nodejs-server-sdk/assets/23323369/567a5195-229d-4466-a29f-760b6dc3a725)
