### PR TITLE
FFM-11656 Sort Group Serving Rules rules when saving to cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-nodejs-server-sdk",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Feature flags SDK for NodeJS environments",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -154,8 +154,6 @@ export class Evaluator {
 
         if (segment?.servingRules?.length) {
           // Use enhanced rules first if they're available
-          segment.servingRules.sort((r1, r2) => r1.priority - r2.priority);
-
           for (const servingRule of segment.servingRules) {
             if (await this.evaluateClauses_v2(servingRule.clauses, target)) {
               return true;

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -58,6 +58,10 @@ export class StorageRepository implements Repository {
     if (await this.isSegmentOutdated(identifier, segment)) {
       return;
     }
+
+    // Sort the serving rules before storing the segment
+    this.sortSegmentServingRules(segment);
+
     const segmentKey = this.formatSegmentKey(identifier);
     if (this.store) {
       await this.store.set(segmentKey, segment);
@@ -165,6 +169,12 @@ export class StorageRepository implements Repository {
     return oldSegment?.version && oldSegment.version >= segment?.version;
   }
 
+  private sortSegmentServingRules(segment: Segment): void {
+    if (segment.servingRules && segment.servingRules.length > 1) {
+      segment.servingRules.sort((r1, r2) => r1.priority - r2.priority);
+    }
+  }
+
   private formatFlagKey(key: string): string {
     return `flags/${key}`;
   }
@@ -172,6 +182,4 @@ export class StorageRepository implements Repository {
   private formatSegmentKey(key: string): string {
     return `segments/${key}`;
   }
-
-
 }


### PR DESCRIPTION
# What
- Move the group `AND/OR` rules outside of the critical evaluation path into the point we save them to the cache.

# Why
Avoid the cost of sorting multiple times during evaluations when it is unnecessary, which can add evaluation latency.

# Testing
TestGrid - both old style and new style scenarios pass.
![Screenshot 2024-06-27 at 17 51 23](https://github.com/harness/ff-nodejs-server-sdk/assets/23323369/27c0d01f-6221-4b3b-873e-03dbab650fd6)
