### PR TITLE
fix: [FFM_12484]: Node SDK doesn't retry after initialisation failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-nodejs-server-sdk",
-      "version": "1.8.6",
+      "version": "1.8.7",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.7.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-nodejs-server-sdk",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "Feature flags SDK for NodeJS environments",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/src/client.ts
+++ b/src/client.ts
@@ -331,10 +331,13 @@ export default class Client {
     const status = error?.response?.status;
     const url = error?.config?.url ?? '';
 
+    if (url.includes('client/auth') && status === 403) {
+      // No point retrying with wrong SDK key
+      return false;
+    }
+
     if (
-      url.includes('client/auth') &&
-      status >= 500 &&
-      status <= 599
+      url.includes('client/auth') && ((status >= 500 && status <= 599) || (status >= 400 && status <= 499))
     ) {
       return true;
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -322,6 +322,11 @@ export default class Client {
       return true;
     }
 
+    // DNS issues, service down, etc
+    if (error.code === 'ENOTFOUND' || error.code === 'ECONNREFUSED') {
+      return true;
+    }
+
     // Auth is a POST request so not covered by isNetworkOrIdempotentRequestError and it's not an aborted connection
     const status = error?.response?.status;
     const url = error?.config?.url ?? '';
@@ -357,7 +362,7 @@ export default class Client {
     const instance: AxiosInstance = axios.create(axiosConfig);
     axiosRetry(instance, {
       retries: options.axiosRetries,
-      retryDelay: axiosRetry.exponentialDelay,
+      retryDelay: (retryCount, error) => axiosRetry.exponentialDelay((retryCount > 7 ? 7 : retryCount), error, 500), // cap to 7 to avoid exponential delays getting too long
       retryCondition: this.axiosRetryCondition,
       shouldResetTimeout: true,
       onRetry: (retryCount, error, requestConfig) => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -45,7 +45,7 @@ export const defaultOptions: Options = {
   store: new FileStore(),
   logger: new ConsoleLog(),
   axiosTimeout: 30000,
-  axiosRetries: 3,
+  axiosRetries: Infinity, // Retry forever unless explicitly overridden
 };
 
 const TARGET_SEGMENT_RULES_QUERY_PARAMETER = 'v2';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.8.6';
+export const VERSION = '1.8.7';


### PR DESCRIPTION
SDK Auth currently does not retry and aborts instantly after 3 (rapid) attempts. This is because AxiosRetry is using default values and needs tuned.

- Updated the retry logic retry indefinitely instead of using default of 3
- Old exponential logic was not working correctly with default values. Instead configure exponential backoff logic with an upper delay limit of approximately 1 min. `axiosRetry.exponentialDelay` will also add a random delay of 20% to avoid retries hitting the BE server all at once across all deployed SDKs.
- Update the retry condition to catch more errors such as `ENOTFOUND` and `ECONNREFUSED` etc

***Testing***
Manual with an SDK proxy that can simulate network failures on the auth
