### PR TITLE
fix: [FFM-12499]: fix uncaught exception when getting flags/segments fails on SSE event

### DIFF
--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -11,8 +11,9 @@ import {
   debugStreamEventReceived,
   infoStreamStopped,
   warnStreamDisconnectedWithRetry,
-  resetDisconnectCounter, restartDisconnectCounter
-} from "./sdk_codes";
+  resetDisconnectCounter,
+  restartDisconnectCounter,
+} from './sdk_codes';
 
 type FetchFunction = (
   identifier: string,
@@ -188,8 +189,8 @@ export class StreamProcessor {
       .on('timeout', () => {
         onFailed(
           'SSE request timed out after ' +
-          StreamProcessor.SSE_TIMEOUT_MS +
-          'ms',
+            StreamProcessor.SSE_TIMEOUT_MS +
+            'ms',
         );
       })
       .setTimeout(StreamProcessor.SSE_TIMEOUT_MS);
@@ -217,16 +218,26 @@ export class StreamProcessor {
           this.api.getFeatureConfigByIdentifier.bind(this.api),
           this.repository.setFlag.bind(this.repository),
           this.repository.deleteFlag.bind(this.repository),
-        ).then(_ => this.log.info(">>SSE Got flag for:", msg.identifier),
-            e => this.log.error(">>SSE Failed to get flag for:", msg.identifier, e))
+        ).then(
+          (_) => this.log.info('>>SSE Got flag for:', msg.identifier),
+          (e) =>
+            this.log.error('>>SSE Failed to get flag for:', msg.identifier, e),
+        );
       } else if (msg.domain === 'target-segment') {
         this.msgProcessor(
           msg,
           this.api.getSegmentByIdentifier.bind(this.api),
           this.repository.setSegment.bind(this.repository),
           this.repository.deleteSegment.bind(this.repository),
-        ).then(_ => this.log.info("SSE Got target-segment for:", msg.identifier),
-          e => this.log.error(">>SSE Failed to get target-segment for:", msg.identifier, e));
+        ).then(
+          (_) => this.log.info('SSE Got target-segment for:', msg.identifier),
+          (e) =>
+            this.log.error(
+              '>>SSE Failed to get target-segment for:',
+              msg.identifier,
+              e,
+            ),
+        );
       }
     }
   }
@@ -277,7 +288,7 @@ export class StreamProcessor {
     this.readyState = StreamProcessor.CLOSED;
     this.log.info('Closing StreamProcessor');
 
-    resetDisconnectCounter()
+    resetDisconnectCounter();
     this.request.destroy();
     this.request = undefined;
 

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -217,14 +217,16 @@ export class StreamProcessor {
           this.api.getFeatureConfigByIdentifier.bind(this.api),
           this.repository.setFlag.bind(this.repository),
           this.repository.deleteFlag.bind(this.repository),
-        );
+        ).then(_ => this.log.info(">>SSE Got flag for:", msg.identifier),
+            e => this.log.error(">>SSE Failed to get flag for:", msg.identifier, e))
       } else if (msg.domain === 'target-segment') {
         this.msgProcessor(
           msg,
           this.api.getSegmentByIdentifier.bind(this.api),
           this.repository.setSegment.bind(this.repository),
           this.repository.deleteSegment.bind(this.repository),
-        );
+        ).then(_ => this.log.info("SSE Got target-segment for:", msg.identifier),
+          e => this.log.error(">>SSE Failed to get target-segment for:", msg.identifier, e));
       }
     }
   }


### PR DESCRIPTION
**What**
This fix adds missing `.then()` calls to the returned promises in `processLine`.

**Why**
An SSE event triggering `getFeatureConfigByIdentifier()` or `getSegmentByIdentifier()` can cause the Node instance to exit if the API call fails. This is because`processLine` does not catch the exception.

For example a 4xx error on these API will cause the following to be logged before aborting:

```
node:internal/process/promises:288
            triggerUncaughtException(err, true /* fromPromise */);
            ^
AxiosError: Request failed with status code 404
```
**Testing**
Manual testing with the SDK debug proxy to force it to return 4xx errors on the SSE event path. Confirmed fix no longer causes process to crash.

