### PR TITLE
Provide tlsTrustedCa/httpsCa to StreamProcessor

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -113,8 +113,15 @@ export default class Client {
     );
     this.evaluator = new Evaluator(this.repository, this.log);
 
+    if (this.options.tlsTrustedCa) {
+      this.httpsCa = fs.readFileSync(this.options.tlsTrustedCa);
+    }
+
     // Setup https client for sass or on-prem connections
-    this.httpsClient = this.createAxiosInstanceWithRetries(this.options);
+    this.httpsClient = this.createAxiosInstanceWithRetries(
+      this.options,
+      this.httpsCa,
+    );
     this.api = new ClientApi(
       this.configuration,
       this.options.baseUrl,
@@ -346,13 +353,15 @@ export default class Client {
     return false;
   }
 
-  private createAxiosInstanceWithRetries(options: Options): AxiosInstance {
+  private createAxiosInstanceWithRetries(
+    options: Options,
+    httpsCa: Buffer,
+  ): AxiosInstance {
     let axiosConfig: AxiosRequestConfig = {
       timeout: options.axiosTimeout,
     };
 
-    if (options.tlsTrustedCa) {
-      const httpsCa = fs.readFileSync(options.tlsTrustedCa);
+    if (httpsCa) {
       // Set axiosConfig with httpsAgent when TLS config is provided
       axiosConfig = {
         ...axiosConfig,


### PR DESCRIPTION
When using the `tlsTrustedCa` option to the Client constructor, it has a private property called httpsCa that is never set. The Client constructor calls `createAxiosInstanceWithRetries`, to create the axios connection used by the PollingProcessor. The `createAxiosInstanceWithRetries` method of the Client class uses the argument `options.tlsTrustedCa` (containing the cert file path) passed to it to read the cert file and provides that to axios. However, the file is read into a local variable, `httpsCa`, *not* the Class property `httpsCa`. The class property `httpsCa` is never set. When the StreamProcessor is created by the Client, one of it's arguments is `this.httpsCa`, which is never set and thus the StreamProcessor never has access to the cert.

When the `baseUrl` and `eventsUrl` are provided with an feature flag proxy Url and the `tlsTrustedCa` option points to a file with the correct cert, the PollingProcessor connects correctly, but the StreamProcessor gives an error `unable to get local issuer certificate` because it never had access to the cert.

This PR makes a few small changes so that the Client property `this.httpsCa` is set from the value of the file provided by the `tlsTrustedCa` constructor argument. That property is then given to both the PollingProcessor and StreamingProcessor.